### PR TITLE
feat: 계정 삭제시 마스킹으로 재가입 허용

### DIFF
--- a/src/main/java/store/lastdance/service/user/UserServiceImpl.java
+++ b/src/main/java/store/lastdance/service/user/UserServiceImpl.java
@@ -144,7 +144,13 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void deactivateUser(UUID userId, HttpServletRequest request, HttpServletResponse response) {
         User user = findByActiveUser(userId);
-        log.info("사용자 계정 비활성화 처리: userId={}", userId);
+        log.info("사용자 계정 삭제(비활성화 처리): userId={}", userId);
+
+        // OAuth 정보 및 이메일 마스킹으로 재가입 허용
+        String deletedSuffix = "deleted_%s".formatted(userId.toString());
+        user.setEmail(deletedSuffix + "@lastdance.store");
+        user.setProviderId(deletedSuffix);
+        user.setNickname(deletedSuffix);
 
         user.deactivate();
         eventPublisher.publishEvent(new UserDeactivatedEvent(this, userId, request, response));
@@ -160,7 +166,7 @@ public class UserServiceImpl implements UserService {
             }
         }
         userRepository.save(user);
-        log.info("계정 비활성화 완료: userId={}", userId);
+        log.info("계정 삭제(비활성화 완료): userId={}", userId);
     }
 
     @Override


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- feature: 계정 삭제시 비활성화 처리 후 이메일, providerId, 닉네임 마스킹 처리로 재가입 허용

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨