### PR TITLE
Feat: 사용자 지출 LLM 분석

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/store/lastdance/aspect/RateLimit.java
+++ b/src/main/java/store/lastdance/aspect/RateLimit.java
@@ -1,0 +1,27 @@
+package store.lastdance.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+    /**
+     * 제한 시간을 정하는 변수
+     * 기본값: 30, 단위: SECONDS
+     */
+    int time() default 30;
+
+    /**
+     * 제한 시간 단위를 정하는 변수
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+
+    /**
+     *  제한 시간 내의 최대 요청 횟수
+     */
+    int count() default 1;
+}

--- a/src/main/java/store/lastdance/aspect/RateLimitingAspect.java
+++ b/src/main/java/store/lastdance/aspect/RateLimitingAspect.java
@@ -1,0 +1,56 @@
+package store.lastdance.aspect;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import store.lastdance.exception.CustomException;
+import store.lastdance.exception.ErrorCode;
+import store.lastdance.security.oauth.CustomOAuth2User;
+
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitingAspect {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Around("@annotation(rateLimit)")
+    public Object rateLimit(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
+        String key = getKey(joinPoint);
+
+        long currentRequests = redisTemplate.opsForValue().increment(key);
+
+        if(currentRequests == 1){
+            redisTemplate.expire(key, rateLimit.time(), rateLimit.unit());
+        }
+        if(currentRequests > rateLimit.count()){
+            log.warn("Rate limit for key : {}. ( {} requests in {} {})",
+                    key, currentRequests, rateLimit.time(), rateLimit.unit().toString().toLowerCase());
+            throw new CustomException(ErrorCode.TOO_MANY_REQUESTS);
+        }
+        return joinPoint.proceed();
+    }
+
+    private String getKey(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getMethod().getName();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())){
+            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
+            }
+
+        CustomOAuth2User userPrincipal = (CustomOAuth2User) authentication.getPrincipal();
+        String userId = userPrincipal.getUserId().toString();
+
+        return "rate-limit:" + userId + ":" + methodName;
+    }
+}

--- a/src/main/java/store/lastdance/config/SecurityConfig.java
+++ b/src/main/java/store/lastdance/config/SecurityConfig.java
@@ -48,6 +48,8 @@ public class SecurityConfig {
                         // 기타 공개 경로들
                         .requestMatchers("/error", "/favicon.ico").permitAll()
                         .requestMatchers("/api/v1/notifications/stream").permitAll()
+                        // /api/v1/expenses/analyze 요청은 인증이 필요함 AOP 프록시
+                        .requestMatchers("/api/v1/expenses/analyze").authenticated()
                         // 나머지 요청은 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/store/lastdance/controller/expense/ExpenseController.java
+++ b/src/main/java/store/lastdance/controller/expense/ExpenseController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import store.lastdance.aspect.RateLimit;
 import store.lastdance.dto.expense.*;
 import store.lastdance.dto.response.ApiResponse;
 import store.lastdance.dto.response.PageWithSummaryResponse;
@@ -232,6 +233,7 @@ public class ExpenseController {
     }
 
     @PostMapping("/analyze")
+    @RateLimit // 30초에 1번만 요청 가능
     @Operation(summary = "LLM 지출 분석 요청", description = "지정된 기간의 지출 내역을 LLM을 통해 분석")
     public ResponseEntity<ApiResponse<AnalyzeExpenseResponseDTO>> analyzeExpenses(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User oAuth2User,

--- a/src/main/java/store/lastdance/dto/expense/AnalyzeExpenseResponseDTO.java
+++ b/src/main/java/store/lastdance/dto/expense/AnalyzeExpenseResponseDTO.java
@@ -1,5 +1,7 @@
 package store.lastdance.dto.expense;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
@@ -51,6 +53,7 @@ public record AnalyzeExpenseResponseDTO(
     ) {}
 
     @Schema(description = "개선 제안 상세")
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record Suggestion(
         @Schema(description = "제목", example = "자동 저축 설정")
         String title,

--- a/src/main/java/store/lastdance/dto/expense/AnalyzeExpenseResponseDTO.java
+++ b/src/main/java/store/lastdance/dto/expense/AnalyzeExpenseResponseDTO.java
@@ -2,41 +2,81 @@ package store.lastdance.dto.expense;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 
-/**
- 8  * LLM 지출 분석 API (POST /api/expenses/analyze)의 응답을 위한 DTO입니다.
- 9  * <p>
- 10  * 서버는 LLM으로부터 받은 분석 결과를 이 DTO 형식으로 가공하여
- 11  * 클라이언트(프론트엔드)에게 반환합니다.
- 12  * Java의 record를 사용하여 불변(immutable) 객체로 간결하게 정의합니다.
- 13  * </p>
- 14  *
- 15  * @param summary             지출 내역에 대한 전반적인 텍스트 요약.
- 16  *                            <p>예: "지난 한 주간 식비에 가장 많은 돈을 사용하셨으며, 특히 배달 음식 지출이 잦았습니다."</p>
- 17  * @param spendingTrends      카테고리별 지출 경향, 금액 등 구조화된 데이터.
- 18  *                            <p>클라이언트에서 차트나 그래프를 시각화하는 데 사용할 수 있습니다.
- 19  *                            예: {"식비": 50000, "교통비": 30000, "카페": 15000}</p>
- 20  * @param savingTips          LLM이 제안하는 구체적인 절약 팁 목록.
- 21  *                            <p>예: ["주 1회는 직접 요리해보기", "출퇴근 시 대중교통 이용하기"]</p>
- 22  * @param goalSettingAdvice   다음 재정 목표 설정을 위한 조언 텍스트.
- 23  *                            <p>예: "다음 달 식비를 10% 줄이는 것을 목표로 설정해보세요."</p>
- 24  * @param analysisDate        분석이 수행된 기간을 나타내는 문자열.
- 25  *                            <p>클라이언트에서 "분석 기간: 2024-07-01 ~ 2024-07-07" 과 같이 표시하는 데 사용할 수 있습니다.</p>
- 26  * @param llmModelUsed        분석에 사용된 LLM 모델의 이름. (디버깅 및 투명성 확보용)
- 27  *                            <p>예: "gemini-1.5-flash"</p>
- 28  *
- 29  * @see store.lastdance.util.gemini.GeminiExpenseAnalyzer#parseExpenseAnalysisResponse(String)
- 30  *      GeminiExpenseAnalyzer에서 LLM의 응답을 이 DTO로 파싱하는 로직을 구현하게 됩니다.
- 31  */
-
-@Schema(description = "LLM 분석 응답")
+@Schema(description = "LLM 지출 분석 결과 응답")
 public record AnalyzeExpenseResponseDTO(
-        String summary,
-        Map<String,Object> spendingTrends,
-        List<String> savingTips,
-        String goalSettingAdvice,
-        String analysisDate,
-        String llmModelUsed
-) {}
+    @Schema(description = "예산 사용률 정보")
+    BudgetUsage budgetUsage,
+
+    @Schema(description = "일평균 지출 정보")
+    DailySpending dailySpending,
+
+    @Schema(description = "분석 결과 요약")
+    AnalysisResult analysisResult,
+
+    @Schema(description = "카테고리별 상세 분석 목록")
+    List<CategoryDetail> categoryDetails
+) {
+
+    @Schema(description = "예산 사용률")
+    public record BudgetUsage(
+        @Schema(description = "사용률 (백분율)", example = "18.1")
+        double percentage,
+
+        @Schema(description = "현재 사용액", example = "361445")
+        BigDecimal currentSpending,
+
+        @Schema(description = "총 예산", example = "2000000")
+        BigDecimal totalBudget
+    ) {}
+
+    @Schema(description = "일평균 지출")
+    public record DailySpending(
+        @Schema(description = "현재까지의 일평균 지출액", example = "51635")
+        BigDecimal averageSoFar,
+
+        @Schema(description = "월말 예상 지출액 (현재 패턴 기준)", example = "1600685")
+        BigDecimal estimatedEom
+    ) {}
+
+    @Schema(description = "분석 결과 및 개선 제안")
+    public record AnalysisResult(
+        @Schema(description = "핵심 소비 패턴 요약", example = "쇼핑 지출 집중")
+        String mainFinding,
+
+        @Schema(description = "개선 제안")
+        Suggestion suggestion
+    ) {}
+
+    @Schema(description = "개선 제안 상세")
+    public record Suggestion(
+        @Schema(description = "제목", example = "자동 저축 설정")
+        String title,
+
+        @Schema(description = "예상 효과", example = "연간 목표 달성률 40% 향상")
+        String effect,
+
+        @Schema(description = "난이도", example = "쉬움")
+        String difficulty,
+        @Schema(description = "구체적인 행동 제안", example = "매월 고정 금액을 자동으로 저축하는 습관을 만들어보세요.")
+        String description
+    ) {}
+
+    @Schema(description = "카테고리별 상세 분석")
+    public record CategoryDetail(
+        @Schema(description = "카테고리명", example = "쇼핑")
+        String category,
+
+        @Schema(description = "지출 비중 (백분율)", example = "55.4")
+        double percentage,
+
+        @Schema(description = "해당 카테고리 총 지출액", example = "200220")
+        BigDecimal totalAmount,
+
+        @Schema(description = "해당 카테고리 지출 건수", example = "3")
+        int transactionCount
+    ) {}
+}
+

--- a/src/main/java/store/lastdance/dto/gemini/GeminiRequestDTO.java
+++ b/src/main/java/store/lastdance/dto/gemini/GeminiRequestDTO.java
@@ -1,0 +1,8 @@
+package store.lastdance.dto.gemini;
+
+import java.util.List;
+
+public record GeminiRequestDTO(List<Content> contents) {
+    public record Content(List<Part> parts){}
+        public record Part(String text){}
+}

--- a/src/main/java/store/lastdance/dto/gemini/GeminiResponseDTO.java
+++ b/src/main/java/store/lastdance/dto/gemini/GeminiResponseDTO.java
@@ -1,0 +1,14 @@
+package store.lastdance.dto.gemini;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GeminiResponseDTO(List<Candidate> candidates) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Candidate(Content content){}
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Content(List<Part> parts){}
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Part(String text){}
+}

--- a/src/main/java/store/lastdance/exception/ErrorCode.java
+++ b/src/main/java/store/lastdance/exception/ErrorCode.java
@@ -78,8 +78,12 @@ public enum ErrorCode {
     REPORT_NOT_FOUND("존재하지 않는 신고 ID입니다.", HttpStatus.NOT_FOUND),
     AI_JUDGMENT_NOT_FOUND("존재하지 않는 AI 판단 ID입니다.", HttpStatus.NOT_FOUND),
 
-    //JSON
-    JSON_PROCESSING_ERROR("JSON 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    //LLM 관련
+    JSON_PROCESSING_ERROR("JSON 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LLM_INVALID_RESPONSE("LLM 응답 처리 중 오류가 발생했습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
+    LLM_PARSING_FAILED("LLM 응답 파싱중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LLM_API_KEY_MISSING("LLM API 키가 설정되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/store/lastdance/exception/ErrorCode.java
+++ b/src/main/java/store/lastdance/exception/ErrorCode.java
@@ -84,6 +84,7 @@ public enum ErrorCode {
     LLM_INVALID_RESPONSE("LLM 응답 처리 중 오류가 발생했습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
     LLM_PARSING_FAILED("LLM 응답 파싱중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     LLM_API_KEY_MISSING("LLM API 키가 설정되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    TOO_MANY_REQUESTS("요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     ;
 
     private final String message;

--- a/src/main/java/store/lastdance/service/expense/ExpenseAnalyzer.java
+++ b/src/main/java/store/lastdance/service/expense/ExpenseAnalyzer.java
@@ -3,5 +3,5 @@ package store.lastdance.service.expense;
 import store.lastdance.dto.expense.AnalyzeExpenseResponseDTO;
 
 public interface ExpenseAnalyzer {
-    AnalyzeExpenseResponseDTO analyzerExpenseData(String expenseJson);
+    AnalyzeExpenseResponseDTO.Suggestion analyzerExpenseData(String expenseJson);
 }

--- a/src/main/java/store/lastdance/service/expense/ExpenseAnalyzerImpl.java
+++ b/src/main/java/store/lastdance/service/expense/ExpenseAnalyzerImpl.java
@@ -13,6 +13,8 @@ import store.lastdance.exception.CustomException;
 import store.lastdance.exception.ErrorCode;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * LLM을 사용하여 사용자의 지출 내역을 분석하는 클라이언트 클래스입니다.
@@ -57,25 +59,27 @@ public class ExpenseAnalyzerImpl implements ExpenseAnalyzer {
         String systemInstruction = """
                 당신은 재정관리 전문가입니다.
                 사용자의 지출 데이터를 기반으로, 불필요한 지출을 줄일 수 있는 가장 효과적인 절약 팁 하나를 제안해주세요.
-                답변은 오직 다음 마크다운 형식의 개선 제안 하나만 포함해야 합니다.
+                답변은 오직 *JSON 형식*에 맞춰 개선 제안 하나만 포함해야 합니다.
                 """;
         String userPrompt = "나의 지출 내역은 다음과 같다: ```json\n" + expenseJson + "\n```\n\n" +
                             "이 데이터를 바탕으로 가장 효과적인 개선 제안 하나를 다음 형식에 맞춰 제공해주세요.";
         String formatInstruction = """
                 ***Format***
                 반드시 첫 줄부터 아래 포맷만 출력하고, 안내 문구나 예시 등은 출력하지 마세요.
-                # 제목 : [개선 제안의 제목]
-                - 제안 내용 : [구체적인 설명, 마크다운 형식으로 작성]
-                - 예상 효과 : [예상되는 효과]
-                - 난이도 : [쉬움/보통/어려움 중 하나]
+                - "title" : [개선 제안의 제목]
+                - "description" : [구체적인 설명, 마크다운 형식으로 작성]
+                - "effect" : [예상되는 효과]
+                - "difficulty" : [쉬움/보통/어려움 중 하나]
 
                 ***Format Example***
-                # 제목 : 자동 저축 설정
-                - 제안 내용 : 매월 고정 금액을 자동으로 저축하는 습관을 만들어보세요. **예상 효과를 강조하거나, 추가적인 팁을 포함할 수 있습니다.**
-                - 예상 효과 : 연간 목표 달성률 40% 향상
-                - 난이도 : 쉬움
+                {
+                "title" : "자동 저축 설정"
+                "description" : "매월 고정 금액을 자동으로 저축하는 습관을 만들어보세요." **예상 효과를 강조하거나, 추가적인 팁을 포함할 수 있습니다.**
+                "effect" : "연간 목표 달성률 40% 향상"
+                "difficulty" : "쉬움"
+                }
                 ************
-                위 형식을 준수하여 작성하세요.
+                위 형식을 반드시 준수하여 JSON 객체만 응답하세요.
                 """;
 
         String finalPrompt = systemInstruction + "\n\n" +
@@ -90,52 +94,39 @@ public class ExpenseAnalyzerImpl implements ExpenseAnalyzer {
         return dto;
     }
     private AnalyzeExpenseResponseDTO.Suggestion parseSuggestionResponse(GeminiResponseDTO responseDTO) {
-
-        try {
-//            JsonNode root = objectMapper.readTree(responseJson);
-//            String textResponse = root.path("candidates")
-//                    .get(0)
-//                    .path("content")
-//                    .path("parts")
-//                    .get(0)
-//                    .path("text").asText();
-
-            String textResponse = responseDTO.candidates().get(0).content().parts().get(0).text();
-
-            log.info("LLM 응답 원본: {}", textResponse); // <== 원본 로그 남기기
-
-            if (textResponse.isEmpty()) {
+        try{
+            log.info("LLM 응답 {}", responseDTO);
+            if(responseDTO == null || responseDTO.candidates() == null || responseDTO.candidates().isEmpty() || responseDTO.candidates().get(0).content() == null || responseDTO.candidates().get(0).content().parts() == null || responseDTO.candidates().get(0).content().parts().isEmpty()) {
+                log.error("LLM 응답이 비어있거나 구조가 올바르지 않습니다.");
                 throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
             }
+            String rawText = responseDTO.candidates().get(0).content().parts().get(0).text();
+            log.info("LLM이 생성한 텍스트 : {}", rawText);
 
-            // LLM 응답 (마크다운 텍스트) 파싱 수정 필요
-            String title = "";
-            String description = "";
-            String effect = "";
-            String difficulty = "";
-
-            String[] lines = textResponse.split("\n");
-            for (String line : lines) {
-                if (line.startsWith("#")) {
-                    title = line.replace("# 제목 :", "").trim();
-                } else if (line.startsWith("- 제안 내용 :")) {
-                    description = line.replace("- 제안 내용 :", "").trim();
-                } else if (line.startsWith("- 예상 효과 :")) {
-                    effect = line.replace("- 예상 효과 :", "").trim();
-                } else if (line.startsWith("- 난이도 :")) {
-                    difficulty = line.replace("- 난이도 :", "").trim();
-                }
-            }
-
-            if (title.isEmpty() || description.isEmpty() || effect.isEmpty() || difficulty.isEmpty()) {
+            String jsonText = null;
+            Pattern p = Pattern.compile("```json\\s*([\\s\\S]+?)\\s*```|```\\s*([\\s\\S]+?)\\s*```", Pattern.CASE_INSENSITIVE);
+            Matcher m = p.matcher(rawText);
+            if(m.find()) {
+                jsonText = m.group(1) != null ? m.group(1) : m.group(2);
+            } else if (rawText.startsWith("{") && rawText.endsWith("}")) {
+                jsonText = rawText;
+            } else {
+                log.error("LLM 응답에 JSON 블록이 없습니다.");
                 throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
             }
+            jsonText = jsonText.trim();
 
-            return new AnalyzeExpenseResponseDTO.Suggestion(title, effect, difficulty, description);
+            AnalyzeExpenseResponseDTO.Suggestion suggestion = objectMapper.readValue(jsonText,AnalyzeExpenseResponseDTO.Suggestion.class);
 
-        } catch (Exception e) { // 일반 예외 처리 추가
-            log.error("LLM 응답 파싱 중 예상치 못한 오류 발생: {}", e.getMessage());
+            return suggestion;
+
+        } catch (JsonProcessingException e){
+            log.error("LLM 응답 JSON 파싱 처리 실패");
+            throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
+        } catch (Exception e) {
+            log.error("LLM 응답 처리중 예상치 못한 오류 발생");
             throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
         }
+
     }
 }

--- a/src/main/java/store/lastdance/service/expense/ExpenseAnalyzerImpl.java
+++ b/src/main/java/store/lastdance/service/expense/ExpenseAnalyzerImpl.java
@@ -1,9 +1,18 @@
 package store.lastdance.service.expense;
 
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import store.lastdance.dto.expense.AnalyzeExpenseResponseDTO;
+import store.lastdance.dto.gemini.GeminiRequestDTO;
+import store.lastdance.dto.gemini.GeminiResponseDTO;
+import store.lastdance.exception.CustomException;
+import store.lastdance.exception.ErrorCode;
+
+import java.util.List;
 
 /**
  * LLM을 사용하여 사용자의 지출 내역을 분석하는 클라이언트 클래스입니다.
@@ -15,11 +24,118 @@ import store.lastdance.dto.expense.AnalyzeExpenseResponseDTO;
  * @see ExpenseService ExpenseService에서 이 클래스를 주입받아 사용하게 됩니다.
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class ExpenseAnalyzerImpl implements ExpenseAnalyzer {
+
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
+
+    public ExpenseAnalyzerImpl(ObjectMapper objectMapper, @Value("${GOOGLE_GEMINI_KEY}") String apiKey
+    ) {
+        this.objectMapper = objectMapper;
+        this.webClient = WebClient.builder()
+                .baseUrl("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=" + apiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
     @Override
-    public AnalyzeExpenseResponseDTO analyzerExpenseData(String expenseJson) {
-        return null;
+    public AnalyzeExpenseResponseDTO.Suggestion analyzerExpenseData(String expenseJson) {
+        String finalPrompt = createPrompt(expenseJson);
+        GeminiRequestDTO requestDTO = createRequestJson(finalPrompt);
+
+        GeminiResponseDTO responseDTO = webClient.post()
+                .bodyValue(requestDTO)
+                .retrieve()
+                .bodyToMono(GeminiResponseDTO.class)
+                .block();
+
+        return parseSuggestionResponse(responseDTO);
+    }
+
+    private String createPrompt(String expenseJson) {
+        String systemInstruction = """
+                당신은 재정관리 전문가입니다.
+                사용자의 지출 데이터를 기반으로, 불필요한 지출을 줄일 수 있는 가장 효과적인 절약 팁 하나를 제안해주세요.
+                답변은 오직 다음 마크다운 형식의 개선 제안 하나만 포함해야 합니다.
+                """;
+        String userPrompt = "나의 지출 내역은 다음과 같다: ```json\n" + expenseJson + "\n```\n\n" +
+                            "이 데이터를 바탕으로 가장 효과적인 개선 제안 하나를 다음 형식에 맞춰 제공해주세요.";
+        String formatInstruction = """
+                ***Format***
+                반드시 첫 줄부터 아래 포맷만 출력하고, 안내 문구나 예시 등은 출력하지 마세요.
+                # 제목 : [개선 제안의 제목]
+                - 제안 내용 : [구체적인 설명, 마크다운 형식으로 작성]
+                - 예상 효과 : [예상되는 효과]
+                - 난이도 : [쉬움/보통/어려움 중 하나]
+
+                ***Format Example***
+                # 제목 : 자동 저축 설정
+                - 제안 내용 : 매월 고정 금액을 자동으로 저축하는 습관을 만들어보세요. **예상 효과를 강조하거나, 추가적인 팁을 포함할 수 있습니다.**
+                - 예상 효과 : 연간 목표 달성률 40% 향상
+                - 난이도 : 쉬움
+                ************
+                위 형식을 준수하여 작성하세요.
+                """;
+
+        String finalPrompt = systemInstruction + "\n\n" +
+                             userPrompt + "\n\n" +
+                             formatInstruction;
+
+        return finalPrompt;
+    }
+    private GeminiRequestDTO createRequestJson(String prompt) {
+        GeminiRequestDTO dto = new GeminiRequestDTO(List.of(new GeminiRequestDTO.Content(List.of(new GeminiRequestDTO.Part(prompt)))));
+
+        return dto;
+    }
+    private AnalyzeExpenseResponseDTO.Suggestion parseSuggestionResponse(GeminiResponseDTO responseDTO) {
+
+        try {
+//            JsonNode root = objectMapper.readTree(responseJson);
+//            String textResponse = root.path("candidates")
+//                    .get(0)
+//                    .path("content")
+//                    .path("parts")
+//                    .get(0)
+//                    .path("text").asText();
+
+            String textResponse = responseDTO.candidates().get(0).content().parts().get(0).text();
+
+            log.info("LLM 응답 원본: {}", textResponse); // <== 원본 로그 남기기
+
+            if (textResponse.isEmpty()) {
+                throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
+            }
+
+            // LLM 응답 (마크다운 텍스트) 파싱 수정 필요
+            String title = "";
+            String description = "";
+            String effect = "";
+            String difficulty = "";
+
+            String[] lines = textResponse.split("\n");
+            for (String line : lines) {
+                if (line.startsWith("#")) {
+                    title = line.replace("# 제목 :", "").trim();
+                } else if (line.startsWith("- 제안 내용 :")) {
+                    description = line.replace("- 제안 내용 :", "").trim();
+                } else if (line.startsWith("- 예상 효과 :")) {
+                    effect = line.replace("- 예상 효과 :", "").trim();
+                } else if (line.startsWith("- 난이도 :")) {
+                    difficulty = line.replace("- 난이도 :", "").trim();
+                }
+            }
+
+            if (title.isEmpty() || description.isEmpty() || effect.isEmpty() || difficulty.isEmpty()) {
+                throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
+            }
+
+            return new AnalyzeExpenseResponseDTO.Suggestion(title, effect, difficulty, description);
+
+        } catch (Exception e) { // 일반 예외 처리 추가
+            log.error("LLM 응답 파싱 중 예상치 못한 오류 발생: {}", e.getMessage());
+            throw new CustomException(ErrorCode.LLM_PARSING_FAILED);
+        }
     }
 }

--- a/src/main/java/store/lastdance/service/expense/ExpenseServiceImpl.java
+++ b/src/main/java/store/lastdance/service/expense/ExpenseServiceImpl.java
@@ -14,6 +14,7 @@ import store.lastdance.domain.expense.ExpenseSplit;
 import store.lastdance.domain.expense.ExpenseType;
 import store.lastdance.domain.group.Group;
 import store.lastdance.domain.group.GroupMember;
+import store.lastdance.domain.user.User;
 import store.lastdance.dto.expense.*;
 import store.lastdance.exception.CustomException;
 import store.lastdance.exception.ErrorCode;
@@ -21,6 +22,7 @@ import store.lastdance.repository.expense.ExpenseRepository;
 import store.lastdance.repository.expense.ExpenseSplitRepository;
 import store.lastdance.repository.group.GroupMemberRepository;
 import store.lastdance.repository.group.GroupRepository;
+import store.lastdance.repository.user.UserRepository;
 import store.lastdance.service.image.ImageService;
 
 import java.math.BigDecimal;
@@ -40,6 +42,7 @@ public class ExpenseServiceImpl implements ExpenseService {
     private final ExpenseSplitRepository expenseSplitRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final UserRepository userRepository;
     private final ImageService imageService;
     private final ObjectMapper objectMapper;
     private final ExpenseAnalyzer expenseAnalyzer;
@@ -681,19 +684,134 @@ public class ExpenseServiceImpl implements ExpenseService {
     private record DateRange(LocalDate startDate, LocalDate endDate) {
     }
 
+    /**
+     * LLM 지출 분석 관련 메서드
+     */
     @Override
     public AnalyzeExpenseResponseDTO analyzeExpenses(UUID userId, AnalyzeExpenseRequestDTO requestDTO) {
         List<Expense> expenses = expenseRepository.findPersonalAndShareExpensesByDateRange(userId, requestDTO.startDate(), requestDTO.endDate());
+        BigDecimal totalBudget = getUserBudget(userId);
 
-        String expenseJson;
-        try {
-            expenseJson = objectMapper.writeValueAsString(expenses);
-        } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.JSON_PROCESSING_ERROR);
+        if (expenses.isEmpty()) {
+            return createEmptyAnalysis(totalBudget);
         }
 
-        AnalyzeExpenseResponseDTO analyzeResult = expenseAnalyzer.analyzerExpenseData(expenseJson);
+        BigDecimal totalSpending = calculateTotalSpending(expenses);
 
-        return analyzeResult; // 임시 반환값
+        AnalyzeExpenseResponseDTO.BudgetUsage budgetUsage = calculateBudgetUsage(totalSpending, totalBudget);
+        AnalyzeExpenseResponseDTO.DailySpending dailySpending = calculateDailySpending(totalSpending,requestDTO.startDate(),requestDTO.endDate());
+
+        List<AnalyzeExpenseResponseDTO.CategoryDetail> categoryDetails = calculateCategoryDetails(expenses,totalSpending);
+
+        AnalyzeExpenseResponseDTO.Suggestion suggestion = getLlmAnalysisResult(expenses);
+
+        String mainFinding = createMainFinding(categoryDetails);
+        AnalyzeExpenseResponseDTO.AnalysisResult analysisResult = new AnalyzeExpenseResponseDTO.AnalysisResult(mainFinding, suggestion);
+
+        return new AnalyzeExpenseResponseDTO(budgetUsage,dailySpending,analysisResult,categoryDetails);
     }
+    /**
+     * 사용자의 예산 정보를 조회합니다.
+     * @param userId 사용자의 UUID
+     * @return 사용자의 예산
+     */
+    private BigDecimal getUserBudget(UUID userId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return BigDecimal.valueOf(user.getUserBudget());
+    }
+    /**
+     * 지출 내역 리스트를 받아 총 지출액 계산
+     */
+    private BigDecimal calculateTotalSpending(List<Expense> expenses) {
+        return expenses.stream()
+                .map(Expense::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+    /**
+    * 예산 사용률 객체 생성
+    */
+    private AnalyzeExpenseResponseDTO.BudgetUsage calculateBudgetUsage(BigDecimal totalSpending, BigDecimal totalBudget){
+        if (totalBudget.compareTo(BigDecimal.ZERO) == 0) {
+            return new AnalyzeExpenseResponseDTO.BudgetUsage(0.0, totalSpending, totalBudget);
+        }
+        BigDecimal percentage = totalSpending.multiply(BigDecimal.valueOf(100)).divide(totalBudget,2,RoundingMode.HALF_UP);
+        return new AnalyzeExpenseResponseDTO.BudgetUsage(percentage.doubleValue(), totalSpending, totalBudget);
+    }
+
+    /**
+     * 일평균, 월말 지출 객체 생성
+     */
+    private AnalyzeExpenseResponseDTO.DailySpending calculateDailySpending(BigDecimal totalSpending, LocalDate startDate, LocalDate endDate){
+        long days = java.time.temporal.ChronoUnit.DAYS.between(startDate, LocalDate.now()) + 1;
+        BigDecimal averageSoFar = totalSpending.divide(BigDecimal.valueOf(days),0,RoundingMode.HALF_UP);
+        int daysInMonth = endDate.lengthOfMonth();
+        BigDecimal estimatedEom = averageSoFar.multiply(BigDecimal.valueOf(daysInMonth)); // 월말 예상 지출
+
+        return new AnalyzeExpenseResponseDTO.DailySpending(averageSoFar,estimatedEom);
+    }
+
+    /**
+     * 카테고리별 상세 분석 객체 리스트 생성
+     */
+    private List<AnalyzeExpenseResponseDTO.CategoryDetail> calculateCategoryDetails(List<Expense> expenses, BigDecimal totalSpending){
+        if(totalSpending.compareTo(BigDecimal.ZERO) == 0){
+            return Collections.emptyList();
+        }
+
+        Map<ExpenseCategory,List<Expense>> expensesByCategory = expenses.stream()
+                .collect(Collectors.groupingBy(Expense::getCategory));
+
+        return expensesByCategory.entrySet().stream()
+                .map(entry -> {
+                    ExpenseCategory category = entry.getKey();
+                    List<Expense> categoryExpenses = entry.getValue();
+                    BigDecimal categoryTotal = calculateTotalSpending(categoryExpenses);
+                    double percentage = categoryTotal.divide(totalSpending,4,RoundingMode.HALF_UP)
+                            .multiply(BigDecimal.valueOf(100)).doubleValue();
+                    int count = categoryExpenses.size();
+                    return new AnalyzeExpenseResponseDTO.CategoryDetail(category.name(),percentage,categoryTotal,count);
+                }).sorted(Comparator.comparing(AnalyzeExpenseResponseDTO.CategoryDetail::percentage).reversed()).toList();
+    }
+
+    /**
+     * LLM으로부터 개선 제안을 받아옴
+     */
+    private AnalyzeExpenseResponseDTO.Suggestion getLlmAnalysisResult(List<Expense> expenses){
+        List<ExpenseResponseDTO> expenseDTOs = expenses.stream()
+                .map(this::convertToResponseDTO)
+                .toList();
+        try{
+            String expenseJson = objectMapper.writeValueAsString(expenseDTOs);
+            return expenseAnalyzer.analyzerExpenseData(expenseJson);
+        } catch (JsonProcessingException e){
+            log.error("DTO to JSON 변환 실패");
+            return new AnalyzeExpenseResponseDTO.Suggestion("데이터 처리중 오류 발생", "잠시 후 다시 시도해주세요.", "오류", "오류");
+        }
+    }
+
+    /**
+     * 분석 데이터 없을 때 반환할 기본 DTO
+     */
+    private AnalyzeExpenseResponseDTO createEmptyAnalysis(BigDecimal totalBudget) {
+        AnalyzeExpenseResponseDTO.BudgetUsage budgetUsage = new AnalyzeExpenseResponseDTO.BudgetUsage(0.0, BigDecimal.ZERO, totalBudget);
+        AnalyzeExpenseResponseDTO.DailySpending dailySpending = new AnalyzeExpenseResponseDTO.DailySpending(BigDecimal.ZERO, BigDecimal.ZERO);
+
+        AnalyzeExpenseResponseDTO.AnalysisResult analysisResult = new AnalyzeExpenseResponseDTO.AnalysisResult("분석할 지출 내역이 없습니다.",
+                new AnalyzeExpenseResponseDTO.Suggestion("지출 내역을 추가하고 다시 시도해주세요.","없음","없음", "없음"));
+
+        return new AnalyzeExpenseResponseDTO(budgetUsage,dailySpending,analysisResult,Collections.emptyList());
+    }
+    /**
+     * 가장 지출이 큰 카테고리를 찾아 분석요약(mainFinding) 생성
+     */
+    private String createMainFinding(List<AnalyzeExpenseResponseDTO.CategoryDetail> categoryDetails) {
+        if (categoryDetails == null || categoryDetails.isEmpty()){
+            return "주요 지출 항목이 없습니다.";
+        }
+        AnalyzeExpenseResponseDTO.CategoryDetail maxCategoryDetail = categoryDetails.get(0);
+
+        return String.format("%s 지출 집중", maxCategoryDetail.category());
+    }
+
 }


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

### feature: LLM 지출분석 기능 및 호출 횟수 제한

LLM을 이용한 지출분석 : 개선제안 부분만 사용되었으며
나머지는 데이터를 이용한 계산입니다.

### feature: AOP, Redis를 이용한 호출횟수 제한

현재 ***30초에 한번만*** 누를 수 있도록 설정해놨습니다.

AOP 프록시 관련 이슈로, SecurityConfig의 접근제한 설정을 추가했습니다.
```java
.requestMatchers("/api/v1/expenses/analyze").authenticated()

```

## 📸 스크린샷 (UI 작업일 경우)
호출 횟수 제한 성공한 모습
![image](https://github.com/user-attachments/assets/2cf1a7b5-e20d-4822-b398-7fe8bff5572a)


## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #16 와 연결됨