### PR TITLE
feat: 악의적 파일 업로드 방지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     // WebClient
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    // https://mvnrepository.com/artifact/org.apache.tika/tika-core
+    implementation 'org.apache.tika:tika-core:3.2.0' // 파일 형식 감지
+
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 

--- a/src/main/java/store/lastdance/service/common/FileValidationService.java
+++ b/src/main/java/store/lastdance/service/common/FileValidationService.java
@@ -1,0 +1,8 @@
+package store.lastdance.service.common;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileValidationService {
+    public void validateImageFile(MultipartFile file);
+
+}

--- a/src/main/java/store/lastdance/service/common/FileValidationServiceImpl.java
+++ b/src/main/java/store/lastdance/service/common/FileValidationServiceImpl.java
@@ -1,0 +1,43 @@
+package store.lastdance.service.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Service;
+import store.lastdance.exception.CustomException;
+import store.lastdance.exception.ErrorCode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Service
+@Slf4j
+public class FileValidationServiceImpl implements FileValidationService{
+        private static final Tika tika = new Tika();
+        private static final List<String> ALLOWED_FILE_TYPES = List.of(
+                "image/jpeg",
+                "image/png",
+                "image/jpg",
+                "image/gif",
+                "image/webp"
+        );
+    @Override
+    public void validateImageFile(org.springframework.web.multipart.MultipartFile file) {
+        if(file == null || file.isEmpty()) {
+            return;
+        }
+
+        try (InputStream inputStream = file.getInputStream()) {
+            String mimeType = tika.detect(inputStream);
+            log.info("Detected MIME type: {} for file: {}", mimeType, file.getOriginalFilename());
+
+            if(!ALLOWED_FILE_TYPES.contains(mimeType)) {
+                log.warn("Attempt to upload an invalid file type. Detected: {}, Filename: {}", mimeType, file.getOriginalFilename());
+                throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+            }
+        } catch (IOException e) {
+            log.error("File validation failed for file: {}", file.getOriginalFilename(), e);
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+}

--- a/src/main/java/store/lastdance/service/image/ImageServiceImpl.java
+++ b/src/main/java/store/lastdance/service/image/ImageServiceImpl.java
@@ -14,6 +14,7 @@ import store.lastdance.domain.common.ImageFile;
 import store.lastdance.exception.CustomException;
 import store.lastdance.exception.ErrorCode;
 import store.lastdance.repository.common.ImageFileRepository;
+import store.lastdance.service.common.FileValidationService;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -26,6 +27,7 @@ public class ImageServiceImpl implements ImageService {
     private final ImageFileRepository imageFileRepository;
     private final S3Operations s3Operations;
     private final S3Presigner s3Presigner;
+    private final FileValidationService fileValidationService;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
@@ -117,21 +119,23 @@ public class ImageServiceImpl implements ImageService {
             throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
-        String contentType = file.getContentType();
-        if (contentType == null || !contentType.startsWith("image/")) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
+        fileValidationService.validateImageFile(file);
 
-        String filename = file.getOriginalFilename();
-        if (filename == null || !isAllowedExtensions(filename)) {
-            throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
-        }
-    }
-
-    private boolean isAllowedExtensions(String filename) {
-        String extension = getFileExtension(filename).toLowerCase();
-        return extension.equals(".jpg") || extension.equals(".jpeg") ||
-                extension.equals(".png") || extension.equals(".gif");
+//        String contentType = file.getContentType();
+//        if (contentType == null || !contentType.startsWith("image/")) {
+//            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+//        }
+//
+//        String filename = file.getOriginalFilename();
+//        if (filename == null || !isAllowedExtensions(filename)) {
+//            throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
+//        }
+//    }
+//
+//    private boolean isAllowedExtensions(String filename) {
+//        String extension = getFileExtension(filename).toLowerCase();
+//        return extension.equals(".jpg") || extension.equals(".jpeg") ||
+//                extension.equals(".png") || extension.equals(".gif");
     }
     
 }


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- feature: 악의적 파일 업로드 방지 구현
의존성 : apache.tika.core:3.2.0 추가
- refactor: 기존 검증로직은 주석 처리

현재 로직은 4단계의 검증을 거칩니다.

1. 빈 파일 검사: 정상적으로 동작합니다.
2. 파일 크기 제한: 정상적으로 동작합니다.
3. Content-Type 검사: (취약점 1) Content-Type 헤더는 클라이언트(브라우저나 Postman 등)가 보내주는 값으로, 쉽게 조작이 가능합니다. 악의적인 사용자가 PDF 파일의 Content-Type을 image/jpeg로 속여서 보낼 수 있습니다.
4. 파일 확장자 검사: (취약점 2) 파일 이름의 확장자(.jpg, .png 등)만 검사합니다. 이것 역시 파일 이름만 document.jpg와 같이 바꾸면 쉽게 우회할 수 있습니다.
### 결론
현재 로직은 파일의 이름과 헤더 정보라는, 전적으로 클라이언트에게 의존하는 정보만을 신뢰하여 파일을 검증하고 있습니다. 
이는 PDF 파일을 JPG로 위장하여 업로드하는 등의 공격에 매우 취약한 상태입니다.

따라서 이 validateImageFile 메소드에 파일의 실제 내용(바이트 스트림)을 분석하여 진짜 파일 형식을 확인하는 로직을 추가했습니다. Apache Tika 사용

## 📸 스크린샷 (UI 작업일 경우)

![image](https://github.com/user-attachments/assets/33414480-fe3e-4f81-a054-3de949558f22)

![image](https://github.com/user-attachments/assets/42849d27-fda4-49d8-ad3a-5872d2ace00e)

txt를 각종 사진 의 확장자로 변경하여 테스트

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #126 와 연결됨