### PR TITLE
feat: 트래픽 급증 알림 및 알림설정 변경

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -61,3 +61,14 @@ groups:
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 로드 에버리지가 높습니다."
       description: "지난 2분간 1분 로드 에버리지(Load1)가 CPU 코어 수의 1.5배를 초과했습니다. 현재 로드1: {{ $value }}"
+
+  # 6. 초당 요청(트래픽) 급증 알림
+  - alert: HighTrafficRate
+    expr: |
+      sum(rate(http_server_requests_seconds_count{job="spring-boot-app"}[5m])) by (instance) > 100
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "인스턴스 {{ $labels.instance }} 에 트래픽이 급증했습니다."
+      description: "지난 2분간 초당 요청 수가 100개를 초과했습니다. 현재: {{ printf "%.2f" $value }} RPS"

--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -10,13 +10,13 @@ groups:
       sum(rate(http_server_requests_seconds_count{status=~"5..", job="spring-boot-app"}[5m]))
       /
       sum(rate(http_server_requests_seconds_count{job="spring-boot-app"}[5m]))
-      > 0.1 # 지난 5분간 5xx 에러율이 10%를 초과할 경우
+      > 0.1 # 지난 1분간 5xx 에러율이 10%를 초과할 경우
     for: 1m
     labels:
       severity: critical
     annotations:
       summary: "애플리케이션 {{ $labels.instance }} 의 HTTP 5xx 에러율이 높습니다."
-      description: "지난 5분간 5xx 에러율이 10% 이상입니다. 현재 에러율: {{ printf \"%.2f\" $value }}%"
+      description: "지난 1분간 5xx 에러율이 10% 이상입니다. 현재 에러율: {{ printf \"%.2f\" $value }}%"
 
   # 2. CPU 사용률 높음 알림
   - alert: HighCpuUsage
@@ -27,7 +27,7 @@ groups:
       severity: warning
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 CPU 사용률이 높습니다."
-      description: "지난 5분간 평균 CPU 사용률이 80%를 초과했습니다. 현재: {{ printf \"%.2f\" $value }}%"
+      description: "지난 2분간 평균 CPU 사용률이 80%를 초과했습니다. 현재: {{ printf \"%.2f\" $value }}%"
 
   # 3. 메모리 사용률 높음 알림
   - alert: HighMemoryUsage
@@ -38,7 +38,7 @@ groups:
       severity: warning
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 메모리 사용률이 높습니다."
-      description: "사용 가능한 메모리가 20% 미만입니다. 현재 사용률: {{ printf \"%.2f\" $value }}%"
+      description: "지난 2분간 사용 가능한 메모리가 20% 미만입니다. 현재 사용률: {{ printf \"%.2f\" $value }}%"
 
   # 4. 디스크 공간 부족 알림
   - alert: DiskAlmostFull
@@ -49,7 +49,7 @@ groups:
       severity: critical
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 디스크 공간이 부족합니다."
-      description: "마운트 지점 {{ $labels.mountpoint }} 의 디스크 사용률이 85% 이상입니다. 현재 사용률: {{ printf \"%.2f\" $value }}%"
+      description: "지난 5분간 마운트 지점 {{ $labels.mountpoint }} 의 디스크 사용률이 85% 이상입니다. 현재 사용률: {{ printf \"%.2f\" $value }}%"
 
   # 5. 높은 로드 에버리지 알림
   - alert: HighLoadAverage
@@ -60,4 +60,4 @@ groups:
       severity: warning
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 로드 에버리지가 높습니다."
-      description: "1분 로드 에버리지(Load1)가 CPU 코어 수의 1.5배를 초과했습니다. 현재 로드1: {{ $value }}"
+      description: "지난 2분간 1분 로드 에버리지(Load1)가 CPU 코어 수의 1.5배를 초과했습니다. 현재 로드1: {{ $value }}"

--- a/monitoring/prometheus/alertmanager.yml
+++ b/monitoring/prometheus/alertmanager.yml
@@ -1,6 +1,9 @@
 # monitoring/prometheus/alertmanager.yml
 # Prometheus Alertmanager 설정 파일 (channel 필드 제거)
 
+global:
+  resolve_timeout: 5m
+
 route:
   group_by: ['alertname', 'instance'] # 같은 alertname과 instance를 가진 알림 그룹화
   group_wait: 30s # 그룹화된 알림을 보내기 전 대기 시간


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 트래픽 급증 알림 추가 및 알림 설명이 실제 감지 시간과 동일하게 변경
> 해결 시 5분 뒤 알람이 오게 변경 [해결 직후 알림이 와버려서 복구 결과 보기 어려웠음]

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- feat: 트래픽 급증 알림 및 알림설정 변경

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #71 와 연결됨