### PR TITLE
refactor: SSE 끊김 문제 온라인 상태관리 로직 Redis로 변경 및 캘린더 무한루프방지

### DIFF
--- a/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
+++ b/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
@@ -35,10 +35,7 @@ public class NotificationSetting {
     // SSE 연결 상태
     @Column(name = "sse_enabled")
     private Boolean sseEnabled = true;
-    @Column(name = "is_online")
-    private Boolean isOnline = false;
-    @Column(name = "last_seen")
-    private LocalDateTime lastSeen;
+    
 
     @Column(name = "created_at")
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -72,25 +69,15 @@ public class NotificationSetting {
         this.checklistReminder = checklistReminder;
     }
 
-    // SSE 연결 상태 관리
-    public void updateOnlineStatus(Boolean isOnline) {
-        LocalDateTime oldLastSeen = this.lastSeen;
-        Boolean oldIsOnline = this.isOnline;
-        
-        this.isOnline = isOnline;
-        this.lastSeen = LocalDateTime.now();
-        
-        // 로깅용 (개발 환경에서만)
-        System.out.println(String.format("UpdateOnlineStatus: userId=%s, old[%s,%s] -> new[%s,%s]", 
-                this.userId, oldIsOnline, oldLastSeen, this.isOnline, this.lastSeen));
-    }
+    
 
     public void updateSSEEnabled(Boolean sseEnabled) {
         this.sseEnabled = sseEnabled;
         // SSE 비활성화시 연결 상태도 초기화
-        if (!sseEnabled) {
-            this.isOnline = false;
-        }
+        // 이 곳에 오프라인 처리가 필요하다면, 이벤트를 발행하거나
+        // ApplicationContext를 통해 OnlineStatusService를 직접 호출해야 합니다.
+        // 현재 구조에서는 엔티티가 서비스에 직접 의존하지 않는 것이 좋으므로,
+        // 이 로직은 서비스를 사용하는 상위 계층으로 이동하는 것을 권장합니다.
     }
 
     // 유틸리티 메서드들

--- a/src/main/java/store/lastdance/service/calendar/CalendarServiceImpl.java
+++ b/src/main/java/store/lastdance/service/calendar/CalendarServiceImpl.java
@@ -305,21 +305,21 @@ public class CalendarServiceImpl implements CalendarService {
         int maxInstances = 1000;
         int instanceCount = 0;
 
-        while (!current.isAfter(actualEnd) && instanceCount < maxInstances) {
+        while (!current.isAfter(actualEnd) && (repeatEnd == null || !current.isAfter(repeatEnd)) && instanceCount < maxInstances) {
             if (!current.isBefore(startDate)) {
                 Calendar instance = createInstanceFromBase(baseCalendar, current, duration);
                 instances.add(instance);
                 instanceCount++;
             }
 
-            // 다음 반복 날짜 계산
-            current = calculateNextOccurrence(current, baseCalendar.getRepeatType());
+            LocalDateTime nextOccurrence = calculateNextOccurrence(current, baseCalendar.getRepeatType());
 
-            // 무한 루프 방지: 다음 날짜가 현재보다 이전이면 중단
-            if (!current.isAfter(baseCalendar.getStartDate().plus(Duration.ofDays((long) instanceCount * 400)))) {
-                log.warn("반복 일정 계산 중 무한 루프 감지, 중단 - 일정 ID: {}", baseCalendar.getCalendarId());
+            // 무한 루프 방지: 다음 발생일이 현재 발생일보다 이전이거나 같으면 중단
+            if (!nextOccurrence.isAfter(current)) {
+                log.warn("반복 일정 계산 중 무한 루프 감지 (날짜 증가 없음), 중단 - 일정 ID: {}", baseCalendar.getCalendarId());
                 break;
             }
+            current = nextOccurrence;
         }
 
         log.info("반복 일정 인스턴스 생성 완료 - 총 {}개 인스턴스", instances.size());

--- a/src/main/java/store/lastdance/service/notification/SSENotificationService.java
+++ b/src/main/java/store/lastdance/service/notification/SSENotificationService.java
@@ -10,7 +10,6 @@ public interface SSENotificationService {
     void disconnectUser(UUID userId);
     boolean sendNotification(UUID userId, String title, String content, NotificationType type, String relatedId);
     boolean isUserOnline(UUID userId);
-    void updateUserOnlineStatus(UUID userId, boolean isOnline);
     void cleanupInactiveConnections();
     int getActiveConnectionCount();
     void shutdown();

--- a/src/main/java/store/lastdance/service/notification/SSENotificationServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/SSENotificationServiceImpl.java
@@ -3,16 +3,13 @@ package store.lastdance.service.notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import store.lastdance.domain.notification.NotificationSetting;
 import store.lastdance.domain.notification.NotificationType;
-import store.lastdance.repository.notification.NotificationSettingRepository;
+import store.lastdance.service.onlinestatus.OnlineStatusService;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.*;
 
@@ -21,11 +18,10 @@ import java.util.concurrent.*;
 @RequiredArgsConstructor
 public class SSENotificationServiceImpl implements SSENotificationService {
 
-    private final NotificationSettingRepository settingRepository;
+    private final OnlineStatusService onlineStatusService; // OnlineStatusService 주입
     private final Map<UUID, SseEmitter> connections = new ConcurrentHashMap<>();
     private final ScheduledExecutorService heartbeatExecutor = Executors.newScheduledThreadPool(2);
     private final Map<UUID, ScheduledFuture<?>> heartbeatTasks = new ConcurrentHashMap<>();
-    private final ExecutorService dbUpdateExecutor = Executors.newFixedThreadPool(5);
 
     @Override
     public SseEmitter createConnection(UUID userId) {
@@ -60,7 +56,7 @@ public class SSENotificationServiceImpl implements SSENotificationService {
                 disconnectUser(userId);
             }
 
-            updateUserOnlineStatusSync(userId, true);
+            onlineStatusService.setUserOnline(userId);
             return emitter;
         }
     }
@@ -80,7 +76,7 @@ public class SSENotificationServiceImpl implements SSENotificationService {
                 log.debug("SSE 연결 정리 중 오류(정상적): {}", e.getMessage());
             }
         }
-        updateUserOnlineStatusSync(userId, false);
+        onlineStatusService.setUserOffline(userId);
     }
 
     @Override
@@ -116,68 +112,10 @@ public class SSENotificationServiceImpl implements SSENotificationService {
 
     @Override
     public boolean isUserOnline(UUID userId) {
-        SseEmitter emitter = connections.get(userId);
-        if (emitter == null) {
-            return false;
-        }
-
-        try {
-            emitter.send(SseEmitter.event()
-                    .name("ping")
-                    .data("ping"));
-            return true;
-        } catch (Exception e) {
-            // 연결 실패 시 즉시 정리
-            disconnectUser(userId);
-            return false;
-        }
+        return onlineStatusService.isUserOnline(userId);
     }
 
-    // 사용자 온라인 상태 업데이트 (동기식으로 변경)
-    private void updateUserOnlineStatusSync(UUID userId, boolean isOnline) {
-        try {
-            updateUserOnlineStatus(userId, isOnline);
-        } catch (Exception e) {
-            log.error("사용자 온라인 상태 업데이트 실패: userId={}, isOnline={}, error={}",
-                    userId, isOnline, e.getMessage(), e);
-            // SSE 연결에는 영향을 주지 않도록 예외를 삼킴
-        }
-    }
-
-    @Override
-    @Transactional
-    public void updateUserOnlineStatus(UUID userId, boolean isOnline) {
-        try {
-            log.debug("사용자 온라인 상태 업데이트 시도: userId={}, isOnline={}", userId, isOnline);
-            
-            Optional<NotificationSetting> settingOpt = settingRepository.findByUserId(userId);
-            
-            if (settingOpt.isPresent()) {
-                NotificationSetting setting = settingOpt.get();
-                setting.updateOnlineStatus(isOnline);
-                NotificationSetting savedSetting = settingRepository.save(setting);
-                log.info("사용자 온라인 상태 업데이트 성공: userId={}, isOnline={}, lastSeen={}", 
-                        userId, isOnline, savedSetting.getLastSeen());
-            } else {
-                // 설정이 없으면 새로 생성
-                if (isOnline) {
-                    NotificationSetting newSetting = NotificationSetting.builder()
-                            .userId(userId)
-                            .build();
-                    newSetting.updateOnlineStatus(true);
-                    NotificationSetting savedSetting = settingRepository.save(newSetting);
-                    log.info("새 알림 설정 생성 및 온라인 상태 설정 성공: userId={}, lastSeen={}", 
-                            userId, savedSetting.getLastSeen());
-                } else {
-                    log.debug("오프라인 상태로 변경 요청이지만 설정이 존재하지 않아 무시: userId={}", userId);
-                }
-            }
-        } catch (Exception e) {
-            log.error("사용자 온라인 상태 업데이트 중 데이터베이스 오류: userId={}, isOnline={}, error={}",
-                    userId, isOnline, e.getMessage(), e);
-            throw e; // 예외를 다시 던져서 호출자가 알 수 있도록 함
-        }
-    }
+    
 
     // SSE 연결 상태 확인 및 정리 (주기적 호출용)
     @Override
@@ -199,7 +137,7 @@ public class SSENotificationServiceImpl implements SSENotificationService {
                 if (task != null) {
                     task.cancel(true);
                 }
-                updateUserOnlineStatusSync(userId, false);
+                onlineStatusService.setUserOffline(userId);
                 return true;
             }
         });
@@ -213,36 +151,7 @@ public class SSENotificationServiceImpl implements SSENotificationService {
         return connections.size();
     }
 
-    // 특정 사용자의 실제 온라인 상태 확인 (DB와 메모리 상태 비교)
-    public boolean isUserActuallyOnline(UUID userId) {
-        // 메모리에 연결이 있는지 확인
-        boolean hasConnection = connections.containsKey(userId);
-        
-        if (!hasConnection) {
-            // 연결이 없으면 DB 상태도 오프라인으로 업데이트
-            updateUserOnlineStatusSync(userId, false);
-            return false;
-        }
-        
-        // 연결이 있으면 실제로 유효한지 ping 테스트
-        try {
-            SseEmitter emitter = connections.get(userId);
-            if (emitter != null) {
-                emitter.send(SseEmitter.event()
-                        .name("ping")
-                        .data("status_check"));
-                
-                // 연결이 유효하면 DB 상태도 온라인으로 업데이트
-                updateUserOnlineStatusSync(userId, true);
-                return true;
-            }
-        } catch (Exception e) {
-            log.debug("사용자 온라인 상태 확인 중 연결 실패: userId={}", userId);
-            disconnectUser(userId);
-        }
-        
-        return false;
-    }
+    
 
     // Heartbeat 스케줄링 - 연결 유지용
     private void scheduleHeartbeat(UUID userId, SseEmitter emitter) {
@@ -284,16 +193,7 @@ public class SSENotificationServiceImpl implements SSENotificationService {
             Thread.currentThread().interrupt();
         }
 
-        // DB 업데이트 executor 정리
-        dbUpdateExecutor.shutdown();
-        try {
-            if (!dbUpdateExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-                dbUpdateExecutor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            dbUpdateExecutor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
+        
 
         // 모든 SSE 연결 정리
         connections.values().forEach(emitter -> {

--- a/src/main/java/store/lastdance/service/onlinestatus/OnlineStatusService.java
+++ b/src/main/java/store/lastdance/service/onlinestatus/OnlineStatusService.java
@@ -1,0 +1,9 @@
+package store.lastdance.service.onlinestatus;
+
+import java.util.UUID;
+
+public interface OnlineStatusService {
+    void setUserOnline(UUID userId);
+    void setUserOffline(UUID userId);
+    boolean isUserOnline(UUID userId);
+}

--- a/src/main/java/store/lastdance/service/onlinestatus/OnlineStatusServiceImpl.java
+++ b/src/main/java/store/lastdance/service/onlinestatus/OnlineStatusServiceImpl.java
@@ -1,0 +1,30 @@
+package store.lastdance.service.onlinestatus;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OnlineStatusServiceImpl implements OnlineStatusService {
+
+    private static final String ONLINE_USER_KEY = "online_users";
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void setUserOnline(UUID userId) {
+        redisTemplate.opsForSet().add(ONLINE_USER_KEY, userId.toString());
+    }
+
+    @Override
+    public void setUserOffline(UUID userId) {
+        redisTemplate.opsForSet().remove(ONLINE_USER_KEY, userId.toString());
+    }
+
+    @Override
+    public boolean isUserOnline(UUID userId) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(ONLINE_USER_KEY, userId.toString()));
+    }
+}


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- refactor: SSE 끊김 문제 온라인 상태관리 로직 Redis로 변경 및 
- fix: 캘린더 무한루프방지

### SSE 계속 끊긴 원인
> 사용자의 실시간 온라인 상태(isOnline)를 관리하는 로직에서는 Redis를 전혀 사용하고 있지 않습니다.
> UpdateOnlineStatus 로그가 계속해서 찍히는 것으로 보아, 온라인 상태는 여전히 RDBMS(PostgreSQL)의 User 테이블에 있는 isOnline 같은 컬럼에 직접 읽고 쓰는 방식으로 처리되고 있을 가능성이 99%입니다.

### 해결방안
**사용자 온라인 상태 관리 로직을 Redis 기반으로 전면 재설계해야 합니다.**

- **사용자가 로그인/로그아웃하거나, 웹소켓/SSE 연결이 생성/종료될 때, DB가 아닌 Redis에 사용자의 온라인 상태를 저장해야 합니다. (예: online_users 라는 Set 자료구조에 userId를 추가/삭제)**
- **사용자의 온라인 여부를 확인할 때도 DB를 조회하는 것이 아니라, Redis를 먼저 확인하도록 로직을 변경.**

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #159 와 연결됨