### PR TITLE
fix: redis 전달로직 변경

### DIFF
--- a/src/main/java/store/lastdance/config/RedisConfig.java
+++ b/src/main/java/store/lastdance/config/RedisConfig.java
@@ -15,8 +15,17 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
 @Configuration
 public class RedisConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {

--- a/src/main/java/store/lastdance/dto/notification/NotificationMessage.java
+++ b/src/main/java/store/lastdance/dto/notification/NotificationMessage.java
@@ -1,0 +1,13 @@
+package store.lastdance.dto.notification;
+
+import store.lastdance.domain.notification.NotificationType;
+
+import java.util.UUID;
+
+public record NotificationMessage(
+    UUID userId,
+    String title,
+    String content,
+    NotificationType type,
+    String relatedId
+) {}

--- a/src/main/java/store/lastdance/service/notification/SSENotificationServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/SSENotificationServiceImpl.java
@@ -13,18 +13,41 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import store.lastdance.dto.notification.NotificationMessage;
+
 @Service
 @Slf4j
-@RequiredArgsConstructor
-public class SSENotificationServiceImpl implements SSENotificationService {
+public class SSENotificationServiceImpl implements SSENotificationService, MessageListener { // MessageListener 구현
 
-    private final OnlineStatusService onlineStatusService; // OnlineStatusService 주입
+    private final OnlineStatusService onlineStatusService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final ObjectMapper objectMapper;
     private final Map<UUID, SseEmitter> connections = new ConcurrentHashMap<>();
     private final ScheduledExecutorService heartbeatExecutor = Executors.newScheduledThreadPool(2, r -> {
         Thread thread = new Thread(r);
         thread.setDaemon(true); // 데몬 스레드로 설정
         return thread;
     });
+    private static final String NOTIFICATION_CHANNEL = "sse-notifications";
+
+    public SSENotificationServiceImpl(OnlineStatusService onlineStatusService, RedisTemplate<String, Object> redisTemplate, RedisMessageListenerContainer redisMessageListenerContainer, ObjectMapper objectMapper) {
+        this.onlineStatusService = onlineStatusService;
+        this.redisTemplate = redisTemplate;
+        this.redisMessageListenerContainer = redisMessageListenerContainer;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    private void init() {
+        redisMessageListenerContainer.addMessageListener(this, new ChannelTopic(NOTIFICATION_CHANNEL));
+    }
     private final Map<UUID, ScheduledFuture<?>> heartbeatTasks = new ConcurrentHashMap<>();
 
     @Override
@@ -85,32 +108,47 @@ public class SSENotificationServiceImpl implements SSENotificationService {
 
     @Override
     public boolean sendNotification(UUID userId, String title, String content, NotificationType type, String relatedId) {
-        SseEmitter emitter = connections.get(userId);
-        if (emitter == null) {
+        if (!onlineStatusService.isUserOnline(userId)) {
+            log.debug("사용자 {}가 오프라인 상태이므로 SSE 알림을 발행하지 않습니다.", userId);
             return false;
         }
 
         try {
-            Map<String, Object> data = Map.of(
-                    "title", title,
-                    "content", content,
-                    "type", type.name(),
-                    "icon", type.getIcon(),
-                    "timestamp", LocalDateTime.now(),
-                    "relatedId", relatedId
-            );
-
-            emitter.send(SseEmitter.event()
-                    .name("notification")
-                    .data(data));
-
-            log.info("SSE 알림 전송 성공: userId={}, type={}", userId, type);
+            NotificationMessage message = new NotificationMessage(userId, title, content, type, relatedId);
+            redisTemplate.convertAndSend(NOTIFICATION_CHANNEL, message);
+            log.info("Redis 채널에 알림 메시지 발행 성공: userId={}, type={}", userId, type);
             return true;
-
-        } catch (IOException e) {
-            log.warn("SSE 알림 전송 실패: userId={}, error={}", userId, e.getMessage());
-            disconnectUser(userId);
+        } catch (Exception e) {
+            log.error("Redis 알림 메시지 발행 실패: userId={}, error={}", userId, e.getMessage(), e);
             return false;
+        }
+    }
+
+    @Override
+    public void onMessage(org.springframework.data.redis.connection.Message message, byte[] pattern) {
+        try {
+            NotificationMessage notificationMessage = objectMapper.readValue(message.getBody(), NotificationMessage.class);
+            UUID userId = notificationMessage.userId();
+
+            SseEmitter emitter = connections.get(userId);
+            if (emitter != null) {
+                Map<String, Object> data = Map.of(
+                        "title", notificationMessage.title(),
+                        "content", notificationMessage.content(),
+                        "type", notificationMessage.type().name(),
+                        "icon", notificationMessage.type().getIcon(),
+                        "timestamp", LocalDateTime.now(),
+                        "relatedId", notificationMessage.relatedId()
+                );
+
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(data));
+
+                log.info("수신된 메시지를 통해 SSE 알림 전송 성공: userId={}, type={}", userId, notificationMessage.type());
+            }
+        } catch (Exception e) {
+            log.error("수신된 Redis 메시지 처리 중 오류 발생: {}", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- fix: redis 전달로직 변경

1. `RedisConfig`: 모든 서버가 메시지를 받을 수 있도록 메시지 리스너 컨테이너를 설정했습니다.
2. `NotificationMessage`: 서버 간에 주고받을 알림 메시지 형식을 record로 정의했습니다.
3. `SSENotificationServiceImpl`:
* 이제 sendNotification 메서드는 알림을 직접 쏘는 대신, Redis의 sse-notifications 채널에 메시지를 발행(Publish)합니다.
* onMessage 메서드는 sse-notifications 채널에 메시지가 도착하면, 자신의 메모리에서 실제 연결을 찾아 최종적으로 사용자에게 알림을 쏩니다.

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #168 와 연결됨