### PR TITLE
Ci/env

### DIFF
--- a/src/main/java/store/lastdance/BeApplication.java
+++ b/src/main/java/store/lastdance/BeApplication.java
@@ -15,7 +15,7 @@ import java.util.TimeZone;
 @EnableConfigurationProperties(OAuth2Properties.class)
 @EnableScheduling  // 스케줄링 활성화
 @EnableJpaRepositories(basePackages = "store.lastdance.repository")
-@EnableRedisRepositories(basePackages = "store.lastdance.repository.notification")
+@EnableRedisRepositories(basePackages = "store.lastdance.repository.redis")
 //@EnableJpaAuditing  // JPA Auditing 활성화
 public class BeApplication {
 

--- a/src/main/java/store/lastdance/repository/redis/NotificationCacheRepository.java
+++ b/src/main/java/store/lastdance/repository/redis/NotificationCacheRepository.java
@@ -1,4 +1,4 @@
-package store.lastdance.repository.notification;
+package store.lastdance.repository.redis;
 
 import org.springframework.data.repository.CrudRepository;
 import store.lastdance.domain.notification.NotificationCache;

--- a/src/main/java/store/lastdance/repository/redis/NotificationReadRepository.java
+++ b/src/main/java/store/lastdance/repository/redis/NotificationReadRepository.java
@@ -1,4 +1,4 @@
-package store.lastdance.repository.notification;
+package store.lastdance.repository.redis;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/store/lastdance/scheduler/NotificationScheduler.java
+++ b/src/main/java/store/lastdance/scheduler/NotificationScheduler.java
@@ -17,7 +17,7 @@ import store.lastdance.repository.calendar.CalendarRepository;
 import store.lastdance.repository.checklist.ChecklistRepository;
 import store.lastdance.repository.expense.ExpenseSplitRepository;
 import store.lastdance.repository.group.GroupRepository;
-import store.lastdance.repository.notification.NotificationCacheRepository;
+import store.lastdance.repository.redis.NotificationCacheRepository;
 import store.lastdance.repository.notification.NotificationSettingRepository;
 import store.lastdance.service.notification.*;
 

--- a/src/main/java/store/lastdance/service/notification/NotificationServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationServiceImpl.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import store.lastdance.domain.notification.NotificationRead;
 import store.lastdance.domain.notification.NotificationType;
-import store.lastdance.repository.notification.NotificationReadRepository;
+import store.lastdance.repository.redis.NotificationReadRepository;
 
 import java.util.UUID;
 


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

1. Redis 전용 패키지 생성 (`.../repository/redis`)
      - JPA 저장소와 Redis 저장소가 같은 패키지(.../notification)에 섞여 있어 발생하는 충돌을 막기 위해, Redis
         저장소만을 위한 store.lastdance.repository.redis 라는 새로운 패키지를 만들었습니다.


  2. Redis 저장소 파일 이동
      - 기존 .../notification 패키지에 있던 Redis 저장소인 NotificationCacheRepository와
        NotificationReadRepository를 새로 만든 .../redis 패키지로 이동시켰습니다.


  3. `import` 경로 수정
      - 위에서 이동시킨 두 개의 저장소를 사용하던 서비스 클래스들(NotificationScheduler,
        NotificationServiceImpl)의 import 경로를 새로운 위치(.../redis)로 수정했습니다.

  4. 메인 애플리케이션 설정 변경 (`BeApplication.java`)
      - @EnableRedisRepositories 어노테이션이 새로운 store.lastdance.repository.redis 패키지를 스캔하도록
        설정을 변경했습니다.

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨