### PR TITLE
fix: redis 제외(역할 명확화)

### DIFF
--- a/src/main/java/store/lastdance/BeApplication.java
+++ b/src/main/java/store/lastdance/BeApplication.java
@@ -3,8 +3,9 @@ package store.lastdance;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -14,7 +15,8 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableConfigurationProperties(OAuth2Properties.class)
 @EnableScheduling  // 스케줄링 활성화
-@EnableJpaRepositories(basePackages = "store.lastdance.repository")
+@EnableJpaRepositories(basePackages = "store.lastdance.repository",
+    excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "store.lastdance.repository.redis.*"))
 @EnableRedisRepositories(basePackages = "store.lastdance.repository.redis")
 //@EnableJpaAuditing  // JPA Auditing 활성화
 public class BeApplication {


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

-  이전 문제: JPA와 Redis가 서로의 영역을 침범하며 충돌했습니다.
   현재 문제 (로그 확인):

  JPA 관리자에게 업무 지시를 더 명확하게 수정
  "`store.lastdance.repository` 전체를 담당하되, `redis` 는 들여다보지 마세요."

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #179 와 연결됨