### PR TITLE
fix: redis SSE 타임아웃 (TCP Keep-Alive 패킷)

### DIFF
--- a/src/main/java/store/lastdance/config/RedisConfig.java
+++ b/src/main/java/store/lastdance/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package store.lastdance.config;
 
 import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
 import io.lettuce.core.TimeoutOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -42,5 +43,21 @@ public class RedisConfig {
         template.setHashValueSerializer(jackson2JsonRedisSerializer);
 
         return template;
+    }
+
+    @Bean
+    public LettuceClientConfiguration lettuceClientConfiguration() {
+        SocketOptions socketOptions = SocketOptions.builder()
+                .keepAlive(true) // TCP Keep-Alive 활성화
+                .connectTimeout(Duration.ofSeconds(10)) // 연결 타임아웃
+                .build();
+
+        ClientOptions clientOptions = ClientOptions.builder()
+                .socketOptions(socketOptions)
+                .build();
+
+        return LettuceClientConfiguration.builder()
+                .clientOptions(clientOptions)
+                .build();
     }
 }


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- fix: SSE 타임아웃 이슈

방화벽이 우리를 잊어버리기 전에 주기적으로 아주 가벼운 신호(TCP Keep-Alive 패킷)를
  보내서 "나 아직 연결 중이야!" 라고 알려주면 됩니다.

  이를 위해, Redis 연결 설정에 TCP Keep-Alive 옵션을 활성화하는 코드를 추가

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨