### PR TITLE
fix: redis SSE 문제

### DIFF
--- a/src/main/java/store/lastdance/config/RedisConfig.java
+++ b/src/main/java/store/lastdance/config/RedisConfig.java
@@ -47,17 +47,15 @@ public class RedisConfig {
 
     @Bean
     public LettuceClientConfiguration lettuceClientConfiguration() {
-        SocketOptions socketOptions = SocketOptions.builder()
-                .keepAlive(true) // TCP Keep-Alive 활성화
-                .connectTimeout(Duration.ofSeconds(10)) // 연결 타임아웃
-                .build();
-
         ClientOptions clientOptions = ClientOptions.builder()
-                .socketOptions(socketOptions)
+                .socketOptions(SocketOptions.builder()
+                        .keepAlive(true)
+                        .connectTimeout(Duration.ofSeconds(10)).build())
                 .build();
 
         return LettuceClientConfiguration.builder()
                 .clientOptions(clientOptions)
+                .commandTimeout(Duration.ofSeconds(10)) // 명령어 타임아웃 10초로 설정
                 .build();
     }
 }


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- fix: SSE 타임아웃 문제
- 1. `SocketOptions` 빌더 인라인화:
       * 이전에는 socketOptions 변수를 따로 선언하여 SocketOptions.builder()...build() 결과를 담았습니다.
       * 이제는 이 SocketOptions.builder()...build() 호출을 ClientOptions.builder().socketOptions(...) 안에
         직접 넣어서 코드를 더 간결하게 만들었습니다. 기능적인 변화는 없습니다. keepAlive(true)와
         connectTimeout(Duration.ofSeconds(10)) 설정은 그대로 유지됩니다.


   2. `commandTimeout` 추가:
       * LettuceClientConfiguration.builder() 체인에 .commandTimeout(Duration.ofSeconds(10)) 이라는 새로운
         설정이 추가되었습니다.
       * 이 설정은 Redis 서버에 명령을 보낸 후 응답을 기다리는 최대 시간을 10초로 지정합니다. 이는
         애플리케이션 시작 시 Redis 연결이 불안정할 때 발생할 수 있는 명령어 타임아웃 문제를 완화하는 데
         도움이 됩니다.

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨