### PR TITLE
refactor: Loki S3 요청량 과다 문제

### DIFF
--- a/monitoring/loki/config.yml
+++ b/monitoring/loki/config.yml
@@ -22,6 +22,13 @@ ingester:                        # ★ 추가·수정
       replication_factor: 1
     num_tokens: 512
     final_sleep: 0s
+  chunk_idle_period: 1h       # 청크가 S3에 쓰여지기 전까지 유휴 상태로 유지되는 시간 (기존 30m에서 1h으로 늘림)
+  chunk_block_size: 262144    # 청크의 블록 크기 (바이트)
+  chunk_retain_period: 7d     # 청크가 로컬에 유지되는 최대 시간 (기존 24h에서 7d으로 늘림)
+  max_chunk_age: 7d           # 청크가 S3에 쓰여지기 전까지 로컬에 유지되는 최대 시간 (기존 24h에서 7d으로 늘림)
+
+compactor:
+  compaction_interval: 10m    # 인덱스 압축 주기
 
 schema_config:
   configs:
@@ -29,7 +36,7 @@ schema_config:
       store: boltdb-shipper
       object_store: s3
       schema: v11
-      index: { prefix: index_, period: 24h }
+      index: { prefix: index_, period: 24h, index_write_period: 24h } # index_write_period는 24h 유지
 
 storage_config:
   boltdb_shipper:


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- refactor: S3 요청 과다로 인한 과도한 요금청구 대처
* 청크 (실제 로그 데이터): 이제 실제 로그 데이터는 Loki 컨테이너의 로컬 디스크에 최대 7일(7d) 동안 보관된
     후 S3로 전송됩니다. (이전에는 최대 24시간)
* 인덱스: 인덱스 데이터는 24시간마다 한 번씩 S3에 쓰여집니다. (이 부분은 이전과 동일합니다. schema_config의
      period 설정과 연관되어 더 늘리기 어렵습니다.)


  이렇게 하면 S3에 대한 PUT/COPY/POST 요청 수가 일주일에 단 몇 번 수준으로 극단적으로 줄어들어 S3 비용이
  거의 발생하지 않을 것입니다.

  매우 중요한 고려사항 (트레이드오프):


   * 데이터 손실 위험 극대화: 로그가 S3로 전송되기 전까지 Loki 컨테이너의 로컬 디스크에 최대 7일 동안
     저장됩니다. 만약 Loki 컨테이너가 7일 이내에 예기치 않게 종료되거나, 컨테이너가 사용하는 볼륨(loki_data)이
      손상되면, S3로 전송되지 않은 최대 7일치의 로그 데이터는 영구적으로 손실될 수 있습니다. 이는 매우 높은
     데이터 손실 위험을 감수하는 것입니다.
   * 로컬 디스크 공간 요구사항 증가: Loki 컨테이너가 실행되는 EC2 인스턴스의 디스크 공간이 7일 동안의 로그
     데이터를 저장할 수 있는 충분한 공간이 필요합니다. 로그 유입량이 많다면 상당한 디스크 공간이 필요할 수
     있습니다.

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨