### PR TITLE
refactor: Loki 로깅 최적화 및 JVM 튜닝

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - SERVER_PORT=8080     #  앱 내부 포트 지정
-      - JAVA_TOOL_OPTIONS=-Xms256m -Xmx640m -XX:+UseSerialGC
+      - JAVA_TOOL_OPTIONS=-Xms640m -Xmx640m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
       #  향후 새로운 환경 변수 추가 시 여기에 이름만 추가해야 합니다.
       - DB_URL
       - DB_USERNAME
@@ -60,7 +60,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - SERVER_PORT=8081     #
-      - JAVA_TOOL_OPTIONS=-Xms256m -Xmx640m -XX:+UseSerialGC
+      - JAVA_TOOL_OPTIONS=-Xms640m -Xmx640m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
       #  향후 새로운 환경 변수 추가 시 여기에 이름만 추가해야 합니다.
       - DB_URL
       - DB_USERNAME

--- a/monitoring/loki/config.yml
+++ b/monitoring/loki/config.yml
@@ -23,9 +23,9 @@ ingester:
     num_tokens: 512
     final_sleep: 0s
   chunk_idle_period: 12h      # 청크가 S3에 쓰여지기 전까지 유휴 상태로 유지되는 시간 (9-to-6 환경 최적화)
-  chunk_block_size: 262144    # 청크의 블록 크기 (바이트)
+  chunk_block_size: 524288    # 청크의 블록 크기 (바이트)
   chunk_retain_period: 72h     # 청크가 로컬에 유지되는 최대 시간 (3일로 줄임)
-  max_chunk_age: 168h           # 청크가 S3에 쓰여지기 전까지 로컬에 유지되는 최대 시간 (기존 24h에서 7d으로 늘림)
+  max_chunk_age: 336h           # 청크가 S3에 쓰여지기 전까지 로컬에 유지되는 최대 시간 (기존 24h에서 7d으로 늘림)
 
 compactor:
   compaction_interval: 10m    # 인덱스 압축 주기

--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -21,13 +21,13 @@ groups:
   # 2. CPU 사용률 높음 알림
   - alert: HighCpuUsage
     expr: |
-      100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+      100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
     for: 10m
     labels:
       severity: warning
     annotations:
       summary: "인스턴스 {{ $labels.instance }} 의 CPU 사용률이 높습니다."
-      description: "지난 10분간 평균 CPU 사용률이 80%를 초과했습니다. 현재: {{ printf \"%.2f\" $value }}%"
+      description: "지난 10분간 평균 CPU 사용률이 90%를 초과했습니다. 현재: {{ printf \"%.2f\" $value }}%"
 
   # 3. 메모리 사용률 높음 알림
   - alert: HighMemoryUsage

--- a/src/main/java/store/lastdance/scheduler/NotificationScheduler.java
+++ b/src/main/java/store/lastdance/scheduler/NotificationScheduler.java
@@ -44,7 +44,7 @@ public class NotificationScheduler {
     @Scheduled(fixedRate = 60000) // 1분마다 실행
     @Transactional(readOnly = true)
     public void processScheduledNotifications() {
-        log.info("=== 알림 스케줄러 실행 시작 ===");
+        log.debug("=== 알림 스케줄러 실행 시작 ===");
 
         try {
             List<User> emailEnabledUsers = notificationSettingService.emailPermitted();
@@ -73,7 +73,7 @@ public class NotificationScheduler {
             log.error("알림 스케줄러 실행 중 전체 오류 발생: {}", e.getMessage(), e);
         }
         
-        log.info("=== 알림 스케줄러 실행 완료 ===");
+        log.debug("=== 알림 스케줄러 실행 완료 ===");
     }
 
     @Scheduled(fixedRate = 300000) // 5분마다 실행
@@ -126,7 +126,7 @@ public class NotificationScheduler {
             LocalDateTime startRange = reminderTime.minusMinutes(2);
             LocalDateTime endRange = reminderTime.plusMinutes(2);
             
-            log.info("일정 알림 체크 - 사용자: {}, 시간 범위: {} ~ {}", 
+            log.debug("일정 알림 체크 - 사용자: {}, 시간 범위: {} ~ {}", 
                 user.getUserId(), startRange, endRange);
             
             // 1. 개인 일정 조회
@@ -203,13 +203,13 @@ public class NotificationScheduler {
                         }
                     }
                 } else {
-                    log.info("이미 발송된 알림이므로 건너뜀 - 사용자: {}, 일정: {}", 
+                    log.debug("이미 발송된 알림이므로 건너뜀 - 사용자: {}, 일정: {}", 
                         user.getUserId(), schedule.getTitle());
                 }
             }
             
             if (allSchedules.isEmpty()) {
-                log.info("15분 후 시작하는 일정이 없음 - 사용자: {}", user.getUserId());
+                log.debug("15분 후 시작하는 일정이 없음 - 사용자: {}", user.getUserId());
             }
         } catch (Exception e) {
             log.error("일정 알림 체크 중 오류 발생 - 사용자: {}, 오류: {}", user.getUserId(), e.getMessage(), e);
@@ -224,13 +224,13 @@ public class NotificationScheduler {
             LocalDateTime startOfDay = today.atStartOfDay();
             LocalDateTime endOfDay = startOfDay.plusDays(1);
             
-            log.info("정산 알림 체크 - 사용자: {}, 오늘 날짜: {}", user.getUserId(), today);
+            log.debug("정산 알림 체크 - 사용자: {}, 오늘 날짜: {}", user.getUserId(), today);
             
             // 오늘 날짜에 생성된 미정산 분담금 조회
             List<ExpenseSplit> unpaidSplitsToday = expenseSplitRepository.findUnpaidSplitsByUserAndDate(
                 user, startOfDay, endOfDay);
 
-            log.info("조회된 오늘 생성된 미정산 분담금 수: {}", unpaidSplitsToday.size());
+            log.debug("조회된 오늘 생성된 미정산 분담금 수: {}", unpaidSplitsToday.size());
 
             for (ExpenseSplit split : unpaidSplitsToday) {
                 String cacheKey = NotificationCache.generateKey(
@@ -256,7 +256,7 @@ public class NotificationScheduler {
                             split.getSplitId().toString()
                         );
                         notificationCacheRepository.save(cache);
-                        log.info("정산 알림 캐시 저장 완료 - 사용자: {}, 지출: {}, 캐시 키: {}",
+                        log.debug("정산 알림 캐시 저장 완료 - 사용자: {}, 지출: {}, 캐시 키: {}",
                             user.getUserId(), expenseTitle, cacheKey);
                         
                         // 1. 실시간 알림
@@ -289,12 +289,12 @@ public class NotificationScheduler {
                         }
                     }
                 } else {
-                    log.info("이미 발송된 정산 알림이므로 건너뜀 - 분담금 ID: {}", split.getSplitId());
+                    log.debug("이미 발송된 정산 알림이므로 건너뜀 - 분담금 ID: {}", split.getSplitId());
                 }
             }
             
             if (unpaidSplitsToday.isEmpty()) {
-                log.info("오늘 생성된 미정산 분담금이 없음 - 사용자: {}", user.getUserId());
+                log.debug("오늘 생성된 미정산 분담금이 없음 - 사용자: {}", user.getUserId());
             }
         } catch (Exception e) {
             log.error("정산 알림 체크 중 오류 발생 - 사용자: {}, 오류: {}", user.getUserId(), e.getMessage(), e);
@@ -307,7 +307,7 @@ public class NotificationScheduler {
             LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
             LocalDateTime endOfDay = startOfDay.plusDays(1);
             
-            log.info("체크리스트 알림 체크 - 사용자: {}, 시간 범위: {} ~ {}", 
+            log.debug("체크리스트 알림 체크 - 사용자: {}, 시간 범위: {} ~ {}", 
                 user.getUserId(), startOfDay, endOfDay);
             
             List<Checklist> dueTodayChecklists = checklistRepository.findByUserIdAndDueDateBetweenAndIsCompletedFalse(
@@ -334,7 +334,7 @@ public class NotificationScheduler {
                             checklist.getChecklistId().toString()
                         );
                         notificationCacheRepository.save(cache);
-                        log.info("체크리스트 알림 캐시 저장 완료 - 사용자: {}, 체크리스트: {}, 캐시키: {}", 
+                        log.debug("체크리스트 알림 캐시 저장 완료 - 사용자: {}, 체크리스트: {}, 캐시키: {}", 
                             user.getUserId(), checklist.getTitle(), cacheKey);
                         
                         // 1. 실시간 알림
@@ -367,12 +367,12 @@ public class NotificationScheduler {
                         }
                     }
                 } else {
-                    log.info("이미 발송된 체크리스트 알림이므로 건너뜀 - 체크리스트: {}", checklist.getTitle());
+                    log.debug("이미 발송된 체크리스트 알림이므로 건너뜀 - 체크리스트: {}", checklist.getTitle());
                 }
             }
             
             if (dueTodayChecklists.isEmpty()) {
-                log.info("오늘 마감인 미완료 체크리스트가 없음 - 사용자: {}", user.getUserId());
+                log.debug("오늘 마감인 미완료 체크리스트가 없음 - 사용자: {}", user.getUserId());
             }
         } catch (Exception e) {
             log.error("체크리스트 알림 체크 중 오류 발생 - 사용자: {}, 오류: {}", user.getUserId(), e.getMessage(), e);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -160,7 +160,7 @@ jwt:
 logging:
   level:
     root: WARN
-    store.lastdance: INFO
+    store.lastdance: WARN
 
 # Swagger 설정
 springdoc:


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- feat: Loki 로깅 최적화 및 JVM 튜닝
    
     이 커밋은 Loki 로깅과 관련된 S3 비용을 절감하고 JVM 성능 및 안정성을 향상시키기 위한 여러
      최적화를 포함합니다.
    
     주요 변경 사항은 다음과 같습니다.
     - Loki S3 비용 최적화:
       - `application-prod.yml`에서 `store.lastdance` 패키지의 로깅 레벨을 `INFO`에서 `WARN`으로
      낮춰 로그 볼륨을 줄였습니다.
       - `monitoring/loki/config.yml`의 Loki 구성을 조정했습니다.
         - `chunk_block_size`를 256KB에서 512KB로 늘려 S3 PUT 요청 빈도를 줄였습니다.
        - `chunk_idle_period`를 12시간으로 되돌려 9-to-6 서버 운영에 맞췄습니다.
        - `max_chunk_age`를 336시간(14일)으로 설정하여 로그 보존 관리를 개선했습니다.
    - 로그 가독성 향상 (개발 환경):
      - `NotificationScheduler.java`의 장황한 `INFO` 레벨 로그를 `DEBUG` 레벨로 리팩토링하여 개발
      로그를 더 깔끔하게 만들었습니다.
    - JVM 성능 및 안정성 튜닝:
      - `docker-compose.yml`의 `blue-app` 및 `green-app`에 대한 `JAVA_TOOL_OPTIONS`를
      업데이트했습니다.
        - `SerialGC`에서 `G1GC`로 전환하여(`-XX:+UseG1GC`) 성능 향상 및 예측 가능한 일시 중지
      시간을 확보했습니다.
        - 초기 및 최대 힙 크기를 640MB로 설정하여(`-Xms640m -Xmx640m`) 예측 가능성을 높였습니다.
        - `MaxGCPauseMillis`를 200ms로 구성하여(`-XX:MaxGCPauseMillis=200`) 애플리케이션 응답성을
      개선했습니다.
    - 모니터링 알림 조정:
      - `monitoring/prometheus/alert.rules`에서 `HighCpuUsage` 알림 임계값을 80%에서 90%로
      변경했습니다.

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #이슈번호 와 연결됨