### PR TITLE
refactor: Loki S3 요청량 과다 문제

### DIFF
--- a/monitoring/loki/config.yml
+++ b/monitoring/loki/config.yml
@@ -22,13 +22,13 @@ ingester:
       replication_factor: 1
     num_tokens: 512
     final_sleep: 0s
-  chunk_idle_period: 12h      # 청크가 S3에 쓰여지기 전까지 유휴 상태로 유지되는 시간 (9-to-6 환경 최적화)
-  chunk_block_size: 524288    # 청크의 블록 크기 (바이트)
-  chunk_retain_period: 72h     # 청크가 로컬에 유지되는 최대 시간 (3일로 줄임)
-  max_chunk_age: 336h           # 청크가 S3에 쓰여지기 전까지 로컬에 유지되는 최대 시간 (기존 24h에서 7d으로 늘림)
+  chunk_idle_period: 24h       # 하루 단위 업로드 (업무 시간만 업로드)
+  chunk_block_size: 4194304    # 4MB로 확대
+  chunk_retain_period: 72h     # 청크가 로컬에 유지되는 최대 시간
+  max_chunk_age: 24h           # 무조건 하루 단위로 S3 업로드
 
 compactor:
-  compaction_interval: 10m    # 인덱스 압축 주기
+  compaction_interval: 6h      # 기존 10분 → 6시간
 
 schema_config:
   configs:
@@ -42,9 +42,10 @@ storage_config:
   boltdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/cache
-    resync_interval: 5s
+    resync_interval: 4h          # 기존 5초 → 4시간
   filesystem:
     directory: /loki/chunks
 
 limits_config:
   allow_structured_metadata: false
+  retention_period: 72h        # 3일만 보관 (스토리지 절감)


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- refactor: Loki S3 요청량 과다 문제
잦은 요청으로 S3 요청량 과다 및 과금 발생.

* boltdb_shipper.resync_interval: 5s에서 4h로 변경.
   * compactor.compaction_interval: 10m에서 6h로 변경.
   * ingester.chunk_idle_period: 12h에서 24h로 변경.
   * ingester.chunk_block_size: 524288 (512KB)에서 4194304 (4MB)로 변경.
   * ingester.max_chunk_age: 336h (14일)에서 24h로 변경.
   * limits_config.retention_period: 72h (3일) 값으로 추가.


## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [ ] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #190 와 연결됨