### PR TITLE
refactor: 헬스체크 및 favicon로 인한 불필요한 로그 개선

### DIFF
--- a/src/main/java/store/lastdance/config/SecurityConfig.java
+++ b/src/main/java/store/lastdance/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,6 +30,11 @@ public class SecurityConfig {
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/favicon.ico");
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
@@ -41,14 +47,14 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // CORS Preflight 요청 허용
-                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/**").permitAll()
                         .requestMatchers("/api/v1/auth/refresh").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         // Actuator 경로 허용 (필요시)
                         .requestMatchers("/actuator/**").permitAll()
                         // 기타 공개 경로들
-                        .requestMatchers("/error", "/favicon.ico").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .requestMatchers("/api/v1/notifications/stream").permitAll()
                         // /api/v1/expenses/analyze 요청은 인증이 필요함 AOP 프록시
                         .requestMatchers("/api/v1/expenses/analyze").authenticated()

--- a/src/main/java/store/lastdance/config/WebConfig.java
+++ b/src/main/java/store/lastdance/config/WebConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
@@ -23,5 +24,9 @@ public class WebConfig implements WebMvcConfigurer {
                 new MediaType("application", "*+json")
         ));
          converters.add(converter);
+    }
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/", "/swagger-ui.html");
     }
 }


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- refactor: 헬스체크 및 favicon로 인한 불필요한 로그 개선
---
### 로드 밸런서의 헬스 체크(Health Check)

- 헬스 체크 동작: AWS의 로드 밸런서(ELB/ALB) 같은 인프라 장비는 서버가 정상적으로 살아있는지 확인하기 위해
주기적으로 특정 경로에 신호를 보냅니다. 이 때 기본 경로가 보통 루트(/)로 설정되어 있습니다.
- 문제 발생: 우리 백엔드 서버는 API만 제공할 뿐, 루트 경로(/)에 해당하는 페이지나 기능이 없었습니다. 따라서
로드 밸런서가 /로 헬스 체크를 할 때마다 서버는 "요청을 처리할 수 없다"고 판단하여 No static resource .
라는 오류 로그를 계속 남겼던 것입니다.
- 해결: 이 문제를 해결하기 위해, / 요청이 들어왔을 때 오류를 내뱉는 대신, 개발자에게 유용한 API
명세서(Swagger UI) 페이지로 보내주도록 리디렉션 처리를 한 것입니다. 이렇게 하면 서버는 헬스 체크 요청을
정상적으로 처리(HTTP 200 또는 302 응답)하게 되어 더 이상 오류 로그를 남기지 않습니다.

결론

 로드 밸런서의 헬스 체크 요청을 정상적으로 처리하여 불필요한 오류 로그를 없애고 서버의 안정성을
높이기 위해 루트 경로 처리를 한 것입니다.

### Favicon 의 yml처리가 완벽하지 않은 이유

1. spring.mvc.favicon.enabled: false (in application.yml)
    - 동작 계층: Spring MVC 계층
    - 역할: 스프링 MVC가 기본적으로 내장하고 있는 파비콘 처리 기능(FaviconHandlerMapping)을 비활성화하는
    역할입니다. 이 기능은 클래스패스(classpath) 루트에 favicon.ico 파일이 있는지 찾아보고, 있으면 제공해주는
    간단한 기능입니다.
    - 한계점: 이 설정은 MVC 계층의 특정 핸들러만 비활성화할 뿐, 들어오는 요청 자체를 막지는 못합니다. 따라서
    요청은 여전히 스프링의 더 앞단(보안 필터 등)을 통과하여 MVC의 DispatcherServlet까지 전달됩니다.
    DispatcherServlet은 이 요청을 처리할 컨트롤러나 리소스를 찾다가 결국 없으면 "리소스를 찾을 수 없음"
    오류를 발생시킬 수 있습니다. 즉, 어설프게 막는 것에 가깝습니다.
2. web.ignoring().requestMatchers("/favicon.ico") (in SecurityConfig)
- 동작 계층: Spring Security 계층 (MVC보다 앞단)
- 역할: 스프링 시큐리티 필터 체인 자체에서 /favicon.ico 요청을 완전히 무시하도록 설정합니다.
- 장점: 이 요청은 인증, 인가 등 어떤 보안 처리도 거치지 않으며, MVC 계층으로 전달되지도 않습니다. 마치
방화벽의 가장 바깥에서 해당 요청을 차단하는 것과 같습니다. 따라서 "리소스를 찾을 수 없음" 오류가 발생할
근본적인 원인을 제거합니다. 이것이 확실하게 막는 방법입니다.

결론

yml 설정만으로는 요청이 서버 깊숙이 들어와서 오류를 발생시킬 가능성이 여전히 남아있었기 때문에, 더 앞단인
보안 계층에서 해당 요청을 원천적으로 무시하도록 SecurityConfig에 추가 작업을 한 것입니다.

---

### 요약

1. 루트 경로(`/`) 처리
    - `WebConfig.java`를 추가하여, 루트 경로(/)로 오는 모든 요청을 API 명세서인 Swagger UI
    페이지(/swagger-ui.html)로 리디렉션하도록 설정했습니다.
2. 파비콘(`favicon.ico`) 요청 처리
    - `SecurityConfig.java`를 수정하여, 브라우저가 자동으로 보내는 /favicon.ico 요청을 보안 필터에서
    무시하도록 설정했습니다. 이를 통해 불필요한 404 오류 로그가 남지 않게 했습니다.

결론: 컨트롤러를 사용하는 대신, 각 기능에 더 적합한 스프링의 설정(WebMvcConfigurer,
WebSecurityCustomizer)을 사용하여 코드를 더 명확하고 효율적으로 개선했습니다.


## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [ ] 로컬에서 기능 정상 작동 확인
- [x] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #206 와 연결됨