### PR TITLE
refactor: S3 요청량 감소 및 취약점 보완

### DIFF
--- a/monitoring/promtail/config.yml
+++ b/monitoring/promtail/config.yml
@@ -122,7 +122,6 @@ scrape_configs:
                 format: RFC3339Nano
             - labels:
                 level:
-                thread:
                 logger:
 
       # 'monitoring-stack' job의 로그에만 logfmt을 적용합니다.

--- a/src/main/java/store/lastdance/config/SecurityConfig.java
+++ b/src/main/java/store/lastdance/config/SecurityConfig.java
@@ -55,7 +55,6 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         // 기타 공개 경로들
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/v1/notifications/stream").permitAll()
                         // /api/v1/expenses/analyze 요청은 인증이 필요함 AOP 프록시
                         .requestMatchers("/api/v1/expenses/analyze").authenticated()
                         // 나머지 요청은 인증 필요


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- refactor: S3 요청량 감소 및 취약점 보완

<img width="1641" height="764" alt="image" src="https://github.com/user-attachments/assets/ffa3a0af-7650-489c-8819-9c0c18ce7864" />

1. S3 요청 과다 및 작은 KB 파일 동시 업로드의 원인

사용자님께서 S3 요청량이 많고, 특히 2025년 8월 14일 오전 9시 1분 28초에 5개의 파일이 동시에 생성되었으며,
이 파일들이 모두 100KB를 넘지 않는다는 중요한 단서를 주셨습니다. 이 현상의 원인은 다음과 같습니다.

- Loki의 청크(Chunk) 저장 방식:
    - Loki는 로그를 S3에 바로 저장하지 않고, 메모리에서 청크(Chunk)라는 단위로 묶습니다. 이 청크는 다음 세 가지 조건 중 하나라도 충족되면 S3로 업로드(플러시)됩니다.
        1. 크기 제한 도달: 청크가 설정된 크기(chunk_block_size, 기본 4MB)에 도달했을 때.
        2. 최대 시간 경과: 청크가 설정된 최대 시간(max_chunk_age, 현재 24시간)보다 오래되었을 때.
        3. 스트림 유휴 기간 경과: 특정 로그 스트림에 더 이상 로그가 들어오지 않고 설정된 유휴
        기간(chunk_idle_period, 현재 24시간)이 지났을 때.
- 문제의 핵심: '고유성이 높은 라벨'과 '시간 제한'의 결합:
    - Promtail의 라벨링: Promtail은 로그를 수집하여 Loki로 보낼 때, 로그에 여러 라벨(예: job, instance,
    level, logger, thread 등)을 붙입니다. Loki는 이 라벨들의 고유한 조합을 하나의 로그 스트림으로
    간주하고, 각 스트림마다 별도의 청크를 생성합니다.
    - `thread` 라벨의 문제: thread 라벨(예: nio-8080-exec-1)은 스레드가 생성/소멸되거나 ID가 바뀌면서 매우
    높은 고유성(high-cardinality)을 가집니다. 즉, 실제 로그 양이 많지 않더라도 thread 라벨 때문에 수많은
    '미니 로그 스트림'이 생성됩니다.
    - 작은 파일의 이유: 이 미니 로그 스트림들은 각각 독립적인 청크를 가지지만, 로그 양이 매우 적기 때문에
    설정된 chunk_block_size (4MB)에 도달하기 어렵습니다. 대신, `max_chunk_age` (24시간) 또는
    `chunk_idle_period` (24시간)와 같은 '시간 제한'에 의해 강제로 S3로 플러시됩니다.
    - 동시 업로드의 이유: 만약 여러 미니 로그 스트림의 청크들이 거의 동시에 24시간이라는 시간 제한에
    도달했다면, Loki는 이들을 한꺼번에 S3로 업로드하게 됩니다. 이것이 동일한 시간에 여러 개의 작은 파일이
    생성된 이유입니다.

요약: S3 요청 과다의 주범은 thread 라벨과 같이 고유성이 높은 라벨들 때문에 불필요하게 많은 수의 로그스트림이 생성되었고, 이들이 로그 양이 적음에도 불구하고 시간 제한에 의해 강제로 S3에 작은 파일로 자주 업로드되었기 때문입니다.

1. thread 라벨을 지운 이유

thread 라벨을 Promtail 설정에서 지운 것은 위에서 설명한 문제의 핵심 원인을 해결하기 위함입니다.

- `thread` 라벨의 특성: thread 라벨은 로그를 발생시킨 스레드의 고유 ID를 포함하는 경우가 많아, 그 값이 매우 자주 변하고 고유한 조합을 많이 만들어냅니다.
- Loki 성능 저하의 주범: Loki는 라벨의 고유한 조합마다 별도의 인덱스와 청크를 관리해야 하므로, thread처럼 고유성이 높은 라벨은 Loki의 메모리 사용량 증가, 쿼리 성능 저하, 그리고 S3에 많은 작은 파일을 생성하는 주된 원인이 됩니다.
- 모니터링 영향 최소화: thread 정보는 로그 메시지 본문(message 필드)에 여전히 포함되어 저장되므로, 필요할 경우 쿼리 시에 정규식 등을 사용하여 추출하거나 검색할 수 있습니다. 즉, 정보 자체가 사라지는 것이 아니라, 인덱싱된 라벨로서의 효율성만 포기하는 것입니다.
- 결과: thread 라벨을 제거함으로써 불필요한 로그 스트림의 생성을 억제하고, S3에 업로드되는 파일의 개수를 줄여 S3 요청량을 감소시키는 효과를 기대할 수 있습니다.


## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #207 와 연결됨