### PR TITLE
refector: 알림 서비스/컨트롤러 V2 명명 규칙 적용 및 Converter 도입

### DIFF
--- a/src/main/java/store/lastdance/controller/notification/NotificationSettingV2Controller.java
+++ b/src/main/java/store/lastdance/controller/notification/NotificationSettingV2Controller.java
@@ -33,6 +33,7 @@ public class NotificationSettingV2Controller {
     public ResponseEntity<ApiResponse<NotificationSettingResponseDTO>> getMySettings(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User user) {
         try{
+            if (user == null) throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
             NotificationSettingResponseDTO setting = settingService.getUserSetting(user.getUserId());
             return ResponseEntity.ok(ApiResponse.success(setting));
         } catch (Exception e) {
@@ -51,6 +52,7 @@ public class NotificationSettingV2Controller {
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정할 알림 설정")
             @RequestBody @jakarta.validation.Valid NotificationSettingRequestDTO request) {
         try {
+            if (user == null) throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
             settingService.updateSetting(user.getUserId(), request);
             return ResponseEntity.ok(ApiResponse.success("알림 설정이 성공적으로 업데이트되었습니다."));
         } catch (Exception e) {

--- a/src/main/java/store/lastdance/controller/notification/NotificationSettingV2Controller.java
+++ b/src/main/java/store/lastdance/controller/notification/NotificationSettingV2Controller.java
@@ -1,0 +1,61 @@
+package store.lastdance.controller.notification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
+import store.lastdance.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import store.lastdance.dto.notification.NotificationSettingRequestDTO;
+import store.lastdance.dto.notification.NotificationSettingResponseDTO;
+import store.lastdance.exception.CustomException;
+import store.lastdance.exception.ErrorCode;
+import store.lastdance.security.oauth.CustomOAuth2User;
+import store.lastdance.service.notification.NotificationSettingV2Service;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v2/notification-settings")
+@RequiredArgsConstructor
+@Tag(name = "알림 설정", description = "사용자 알림 설정 관리 API")
+public class NotificationSettingV2Controller {
+
+    private final NotificationSettingV2Service settingService;
+
+    @GetMapping("/me")
+    @Operation(
+        summary = "내 알림 설정 조회",
+        description = "현재 로그인한 사용자의 알림 설정을 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<NotificationSettingResponseDTO>> getMySettings(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User user) {
+        try{
+            NotificationSettingResponseDTO setting = settingService.getUserSetting(user.getUserId());
+            return ResponseEntity.ok(ApiResponse.success(setting));
+        } catch (Exception e) {
+            log.error("알림 설정 조회 실패 - 사용자: {}, 에러: {}", user.getUserId(), e.getMessage(), e);
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_FOUND_FAILED);
+        }
+    }
+
+    @PatchMapping("/me")
+    @Operation(
+            summary = "내 알림 설정 수정",
+            description = "현재 로그인한 사용자의 알림 설정을 수정합니다."
+    )
+    public ResponseEntity<ApiResponse<String>> updateMySettings(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User user,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정할 알림 설정")
+            @RequestBody @jakarta.validation.Valid NotificationSettingRequestDTO request) {
+        try {
+            settingService.updateSetting(user.getUserId(), request);
+            return ResponseEntity.ok(ApiResponse.success("알림 설정이 성공적으로 업데이트되었습니다."));
+        } catch (Exception e) {
+            log.error("알림 설정 수정 실패 - 사용자: {}, 에러: {}", user.getUserId(), e.getMessage(), e);
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_UPDATE_FAILED);
+        }
+    }
+}

--- a/src/main/java/store/lastdance/converter/notification/NotificationSettingConverter.java
+++ b/src/main/java/store/lastdance/converter/notification/NotificationSettingConverter.java
@@ -1,0 +1,29 @@
+package store.lastdance.converter.notification;
+
+import org.springframework.stereotype.Component;
+import store.lastdance.domain.notification.NotificationSetting;
+import store.lastdance.dto.notification.NotificationSettingResponseDTO;
+
+import java.util.UUID;
+
+@Component
+public class NotificationSettingConverter {
+    public NotificationSetting toEntity(UUID userId) {
+        return NotificationSetting.builder()
+                .userId(userId)
+                .build();
+    }
+
+    public NotificationSettingResponseDTO toDto(NotificationSetting notificationSetting) {
+        return NotificationSettingResponseDTO.builder()
+                .settingId(notificationSetting.getSettingId())
+                .userId(notificationSetting.getUserId())
+                .emailEnabled(notificationSetting.getEmailEnabled())
+                .scheduleReminder(notificationSetting.getScheduleReminder())
+                .paymentReminder(notificationSetting.getPaymentReminder())
+                .checklistReminder(notificationSetting.getChecklistReminder())
+                .sseEnabled(notificationSetting.getSseEnabled())
+                .createdAt(notificationSetting.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/store/lastdance/converter/notification/NotificationSettingConverter.java
+++ b/src/main/java/store/lastdance/converter/notification/NotificationSettingConverter.java
@@ -18,11 +18,11 @@ public class NotificationSettingConverter {
         return NotificationSettingResponseDTO.builder()
                 .settingId(notificationSetting.getSettingId())
                 .userId(notificationSetting.getUserId())
-                .emailEnabled(notificationSetting.getEmailEnabled())
-                .scheduleReminder(notificationSetting.getScheduleReminder())
-                .paymentReminder(notificationSetting.getPaymentReminder())
-                .checklistReminder(notificationSetting.getChecklistReminder())
-                .sseEnabled(notificationSetting.getSseEnabled())
+                .emailEnabled(notificationSetting.isEmailEnabled())
+                .scheduleReminder(notificationSetting.isScheduleReminder())
+                .paymentReminder(notificationSetting.isPaymentReminder())
+                .checklistReminder(notificationSetting.isChecklistReminder())
+                .sseEnabled(notificationSetting.isSseEnabled())
                 .createdAt(notificationSetting.getCreatedAt())
                 .build();
     }

--- a/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
+++ b/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
@@ -21,20 +21,19 @@ public class NotificationSetting {
     private UUID userId;
 
     @Column(name = "email_enabled")
-    private Boolean emailEnabled = true;
+    private Boolean emailEnabled = false;
 
     @Column(name = "schedule_reminder")
-    private Boolean scheduleReminder = true;
+    private Boolean scheduleReminder = false;
 
     @Column(name = "payment_reminder")
-    private Boolean paymentReminder = true;
+    private Boolean paymentReminder = false;
 
     @Column(name = "checklist_reminder")
-    private Boolean checklistReminder = true;
+    private Boolean checklistReminder = false;
 
-    // SSE 연결 상태
     @Column(name = "sse_enabled")
-    private Boolean sseEnabled = true;
+    private Boolean sseEnabled = false;
     
 
     @Column(name = "created_at")
@@ -69,16 +68,7 @@ public class NotificationSetting {
         this.checklistReminder = checklistReminder;
     }
 
-    
-
-    public void updateSSEEnabled(Boolean sseEnabled) {
-        this.sseEnabled = sseEnabled;
-        // SSE 비활성화시 연결 상태도 초기화
-        // 이 곳에 오프라인 처리가 필요하다면, 이벤트를 발행하거나
-        // ApplicationContext를 통해 OnlineStatusService를 직접 호출해야 합니다.
-        // 현재 구조에서는 엔티티가 서비스에 직접 의존하지 않는 것이 좋으므로,
-        // 이 로직은 서비스를 사용하는 상위 계층으로 이동하는 것을 권장합니다.
-    }
+    public void updateSSEEnabled(Boolean sseEnabled) { this.sseEnabled = sseEnabled; }
 
     // 유틸리티 메서드들
     public boolean isNotificationEnabled(NotificationType type) {

--- a/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
+++ b/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
@@ -20,21 +20,21 @@ public class NotificationSetting {
     @Column(name = "user_id", unique = true, nullable = false)
     private UUID userId;
 
-    @Column(name = "email_enabled")
-    private Boolean emailEnabled = false;
+    @Getter
+    @Column(name = "email_enabled", nullable = false)
+    private boolean emailEnabled = false;
 
-    @Column(name = "schedule_reminder")
-    private Boolean scheduleReminder = false;
+    @Column(name = "schedule_reminder", nullable = false)
+    private boolean scheduleReminder = false;
 
-    @Column(name = "payment_reminder")
-    private Boolean paymentReminder = false;
+    @Column(name = "payment_reminder", nullable = false)
+    private boolean paymentReminder = false;
 
-    @Column(name = "checklist_reminder")
-    private Boolean checklistReminder = false;
+    @Column(name = "checklist_reminder", nullable = false)
+    private boolean checklistReminder = false;
 
-    @Column(name = "sse_enabled")
-    private Boolean sseEnabled = false;
-
+    @Column(name = "sse_enabled", nullable = false)
+    private boolean sseEnabled = false;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -46,42 +46,32 @@ public class NotificationSetting {
     @Builder
     public NotificationSetting(@NonNull UUID userId) {
         this.userId = userId;
-        this.emailEnabled = false;
-        this.scheduleReminder = false;
-        this.paymentReminder = false;
-        this.checklistReminder = false;
-        this.sseEnabled = false;
     }
 
-    public void updateEmailEnabled(Boolean emailEnabled) {
+    public void updateEmailEnabled(boolean emailEnabled) {
         this.emailEnabled = emailEnabled;
     }
 
-    public void updateScheduleReminder(Boolean scheduleReminder) {
+    public void updateScheduleReminder(boolean scheduleReminder) {
         this.scheduleReminder = scheduleReminder;
     }
 
-    public void updatePaymentReminder(Boolean paymentReminder) {
+    public void updatePaymentReminder(boolean paymentReminder) {
         this.paymentReminder = paymentReminder;
     }
 
-    public void updateChecklistReminder(Boolean checklistReminder) {
+    public void updateChecklistReminder(boolean checklistReminder) {
         this.checklistReminder = checklistReminder;
     }
 
-    public void updateSSEEnabled(Boolean sseEnabled) { this.sseEnabled = sseEnabled; }
+    public void updateSSEEnabled(boolean sseEnabled) { this.sseEnabled = sseEnabled; }
 
-    // 유틸리티 메서드들
     public boolean isNotificationEnabled(NotificationType type) {
         return switch (type) {
-            case SCHEDULE -> scheduleReminder != null && scheduleReminder;
-            case PAYMENT -> paymentReminder != null && paymentReminder;
-            case CHECKLIST -> checklistReminder != null && checklistReminder;
+            case SCHEDULE -> scheduleReminder;
+            case PAYMENT -> paymentReminder;
+            case CHECKLIST -> checklistReminder;
         };
-    }
-
-    public boolean isEmailEnabled() {
-        return emailEnabled != null && emailEnabled;
     }
 
     public boolean isEmailEnabledForType(NotificationType type) {

--- a/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
+++ b/src/main/java/store/lastdance/domain/notification/NotificationSetting.java
@@ -34,7 +34,7 @@ public class NotificationSetting {
 
     @Column(name = "sse_enabled")
     private Boolean sseEnabled = false;
-    
+
 
     @Column(name = "created_at")
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -46,10 +46,11 @@ public class NotificationSetting {
     @Builder
     public NotificationSetting(@NonNull UUID userId) {
         this.userId = userId;
-        this.emailEnabled = true;
-        this.scheduleReminder = true;
-        this.paymentReminder = true;
-        this.checklistReminder = true;
+        this.emailEnabled = false;
+        this.scheduleReminder = false;
+        this.paymentReminder = false;
+        this.checklistReminder = false;
+        this.sseEnabled = false;
     }
 
     public void updateEmailEnabled(Boolean emailEnabled) {

--- a/src/main/java/store/lastdance/exception/ErrorCode.java
+++ b/src/main/java/store/lastdance/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package store.lastdance.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import store.lastdance.dto.community.comment.CommentResponseDTO;
 
@@ -106,7 +107,14 @@ public enum ErrorCode {
     CALENDAR_INVALID_REPEAT_DATE_ORDER("반복 종료일은 일정 시작일보다 이후여야 합니다.", HttpStatus.BAD_REQUEST),
     CALENDAR_REPEAT_REQUIRED("반복 타입은 필수입니다.", HttpStatus.BAD_REQUEST),
     CALENDAR_DATE_REQUIRED("시작날짜와 종료날짜를 입력해주세요.", HttpStatus.BAD_REQUEST),
-    INVALID_DATE_ORDER("시작날짜는 종료날짜보다 앞에 있어야 합니다.", HttpStatus.BAD_REQUEST);
+    INVALID_DATE_ORDER("시작날짜는 종료날짜보다 앞에 있어야 합니다.", HttpStatus.BAD_REQUEST),
+
+    //알림 관련
+    NOTIFICATION_SETTING_CREATE_FAILED("알림 설정 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_SETTING_NOT_FOUND("알림 설정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_SETTING_FOUND_FAILED("알림 설정 조회에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_SETTING_UPDATE_FAILED("알림 설정 수정에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_SETTING_ALREADY_EXISTS("사용자의 알림 설정이 이미 존재합니다", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/store/lastdance/exception/ErrorCode.java
+++ b/src/main/java/store/lastdance/exception/ErrorCode.java
@@ -111,9 +111,9 @@ public enum ErrorCode {
 
     //알림 관련
     NOTIFICATION_SETTING_CREATE_FAILED("알림 설정 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
-    NOTIFICATION_SETTING_NOT_FOUND("알림 설정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTIFICATION_SETTING_FOUND_FAILED("알림 설정 조회에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
     NOTIFICATION_SETTING_UPDATE_FAILED("알림 설정 수정에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_SETTING_NOT_FOUND("알림 설정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTIFICATION_SETTING_ALREADY_EXISTS("사용자의 알림 설정이 이미 존재합니다", HttpStatus.CONFLICT);
 
     private final String message;

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingServiceImpl.java
@@ -44,11 +44,11 @@ public class NotificationSettingServiceImpl implements NotificationSettingServic
         return NotificationSettingResponseDTO.builder()
                 .settingId(setting.getSettingId())
                 .userId(setting.getUserId())
-                .emailEnabled(setting.getEmailEnabled() != null ? setting.getEmailEnabled() : true)
-                .scheduleReminder(setting.getScheduleReminder() != null ? setting.getScheduleReminder() : true)
-                .paymentReminder(setting.getPaymentReminder() != null ? setting.getPaymentReminder() : true)
-                .checklistReminder(setting.getChecklistReminder() != null ? setting.getChecklistReminder() : true)
-                .sseEnabled(setting.getSseEnabled() != null ? setting.getSseEnabled() : true)
+                .emailEnabled(setting.isEmailEnabled())
+                .scheduleReminder(setting.isScheduleReminder())
+                .paymentReminder(setting.isPaymentReminder())
+                .checklistReminder(setting.isChecklistReminder())
+                .sseEnabled(setting.isSseEnabled())
                 .createdAt(setting.getCreatedAt())
                 .build();
     }
@@ -98,10 +98,10 @@ public class NotificationSettingServiceImpl implements NotificationSettingServic
             settingRepository.save(defaultSetting);
             log.info("사용자 기본 알림 설정 생성 완료: userId={}, emailEnabled={}, scheduleReminder={}, paymentReminder={}, checklistReminder={}", 
                     userId, 
-                    defaultSetting.getEmailEnabled(),
-                    defaultSetting.getScheduleReminder(),
-                    defaultSetting.getPaymentReminder(),
-                    defaultSetting.getChecklistReminder());
+                    defaultSetting.isEmailEnabled(),
+                    defaultSetting.isScheduleReminder(),
+                    defaultSetting.isPaymentReminder(),
+                    defaultSetting.isChecklistReminder());
         } catch (Exception e) {
             log.error("사용자 기본 알림 설정 생성 실패: userId={}, error={}", userId, e.getMessage(), e);
             throw e;

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2Service.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2Service.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface NotificationSettingV2Service {
     NotificationSettingResponseDTO getUserSetting(UUID userId);
-    void updateSetting(UUID userId, NotificationSettingRequestDTO request);
+    NotificationSettingResponseDTO updateSetting(UUID userId, NotificationSettingRequestDTO request);
     
     void createDefaultSetting(UUID userId);
 }

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2Service.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2Service.java
@@ -1,0 +1,15 @@
+package store.lastdance.service.notification;
+
+import store.lastdance.domain.user.User;
+import store.lastdance.dto.notification.NotificationSettingRequestDTO;
+import store.lastdance.dto.notification.NotificationSettingResponseDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationSettingV2Service {
+    NotificationSettingResponseDTO getUserSetting(UUID userId);
+    void updateSetting(UUID userId, NotificationSettingRequestDTO request);
+    
+    void createDefaultSetting(UUID userId);
+}

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
@@ -3,6 +3,7 @@ package store.lastdance.service.notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import store.lastdance.converter.notification.NotificationSettingConverter;
 import store.lastdance.domain.notification.NotificationSetting;
 import store.lastdance.dto.notification.NotificationSettingRequestDTO;
 import store.lastdance.dto.notification.NotificationSettingResponseDTO;
@@ -18,62 +19,47 @@ import java.util.UUID;
 public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Service {
 
     private final NotificationSettingRepository settingRepository;
+    private final NotificationSettingConverter notificationSettingConverter;
 
     @Override
     public NotificationSettingResponseDTO getUserSetting(UUID userId) {
-        NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
-        if (setting == null) {
-            createDefaultSetting(userId);
-            return NotificationSettingResponseDTO.builder()
-                    .settingId(null)
-                    .userId(userId)
-                    .emailEnabled(false)
-                    .scheduleReminder(false)
-                    .paymentReminder(false)
-                    .checklistReminder(false)
-                    .sseEnabled(false)
-                    .createdAt(null)
-                    .build();
-        }
+        try{
+            NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
+            if (setting == null) createDefaultSetting(userId);
+            if (setting == null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND);
 
-        return NotificationSettingResponseDTO.builder()
-                .settingId(setting.getSettingId())
-                .userId(setting.getUserId())
-                .emailEnabled(setting.getEmailEnabled() != null ? setting.getEmailEnabled() : true)
-                .scheduleReminder(setting.getScheduleReminder() != null ? setting.getScheduleReminder() : true)
-                .paymentReminder(setting.getPaymentReminder() != null ? setting.getPaymentReminder() : true)
-                .checklistReminder(setting.getChecklistReminder() != null ? setting.getChecklistReminder() : true)
-                .sseEnabled(setting.getSseEnabled() != null ? setting.getSseEnabled() : true)
-                .createdAt(setting.getCreatedAt())
-                .build();
+            return notificationSettingConverter.toDto(setting);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_UPDATE_FAILED);
+        }
     }
 
     @Override
     public void updateSetting(UUID userId, NotificationSettingRequestDTO request) {
-        NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
+        try{
+            NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
 
-        if (setting == null) {
-            setting = NotificationSetting.builder()
-                    .userId(userId)
-                    .build();
-        }
+            if (setting == null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND);
 
-        if (request.getEmailEnabled() != null) {
-            setting.updateEmailEnabled(request.getEmailEnabled());
+            if (request.getEmailEnabled() != null) {
+                setting.updateEmailEnabled(request.getEmailEnabled());
+            }
+            if (request.getScheduleReminder() != null) {
+                setting.updateScheduleReminder(request.getScheduleReminder());
+            }
+            if (request.getPaymentReminder() != null) {
+                setting.updatePaymentReminder(request.getPaymentReminder());
+            }
+            if (request.getChecklistReminder() != null) {
+                setting.updateChecklistReminder(request.getChecklistReminder());
+            }
+            if (request.getSseEnabled() != null) {
+                setting.updateSSEEnabled(request.getSseEnabled());
+            }
+            settingRepository.save(setting);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_UPDATE_FAILED);
         }
-        if (request.getScheduleReminder() != null) {
-            setting.updateScheduleReminder(request.getScheduleReminder());
-        }
-        if (request.getPaymentReminder() != null) {
-            setting.updatePaymentReminder(request.getPaymentReminder());
-        }
-        if (request.getChecklistReminder() != null) {
-            setting.updateChecklistReminder(request.getChecklistReminder());
-        }
-        if (request.getSseEnabled() != null) {
-            setting.updateSSEEnabled(request.getSseEnabled());
-        }
-        settingRepository.save(setting);
     }
 
     @Override
@@ -82,9 +68,7 @@ public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Se
             NotificationSetting existing = settingRepository.findByUserId(userId).orElse(null);
             if (existing != null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_ALREADY_EXISTS);
 
-            NotificationSetting defaultSetting = NotificationSetting.builder()
-                    .userId(userId)
-                    .build();
+            NotificationSetting defaultSetting = notificationSettingConverter.toEntity(userId);
             
             settingRepository.save(defaultSetting);
 

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
@@ -3,6 +3,7 @@ package store.lastdance.service.notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import store.lastdance.converter.notification.NotificationSettingConverter;
 import store.lastdance.domain.notification.NotificationSetting;
 import store.lastdance.dto.notification.NotificationSettingRequestDTO;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Service {
 
     private final NotificationSettingRepository settingRepository;
@@ -24,39 +26,51 @@ public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Se
     @Override
     public NotificationSettingResponseDTO getUserSetting(UUID userId) {
         try{
-            NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
-            if (setting == null) createDefaultSetting(userId);
-            if (setting == null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND);
+            NotificationSetting setting = settingRepository.findByUserId(userId)
+                    .orElseGet(() -> settingRepository.save(
+                            notificationSettingConverter.toEntity(userId)));
 
             return notificationSettingConverter.toDto(setting);
+        } catch (CustomException ce) {
+            throw ce;
         } catch (Exception e) {
             throw new CustomException(ErrorCode.NOTIFICATION_SETTING_UPDATE_FAILED);
         }
     }
 
     @Override
-    public void updateSetting(UUID userId, NotificationSettingRequestDTO request) {
+    public NotificationSettingResponseDTO updateSetting(UUID userId, NotificationSettingRequestDTO request) {
         try{
-            NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
+            NotificationSetting setting = settingRepository.findByUserId(userId)    .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND));
 
-            if (setting == null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND);
-
+            boolean updated = false;
             if (request.getEmailEnabled() != null) {
                 setting.updateEmailEnabled(request.getEmailEnabled());
+                updated = true;
             }
             if (request.getScheduleReminder() != null) {
                 setting.updateScheduleReminder(request.getScheduleReminder());
+                updated = true;
             }
             if (request.getPaymentReminder() != null) {
                 setting.updatePaymentReminder(request.getPaymentReminder());
+                updated = true;
             }
             if (request.getChecklistReminder() != null) {
                 setting.updateChecklistReminder(request.getChecklistReminder());
+                updated = true;
             }
             if (request.getSseEnabled() != null) {
                 setting.updateSSEEnabled(request.getSseEnabled());
+                updated = true;
             }
-            settingRepository.save(setting);
+
+            if (updated) {
+                settingRepository.save(setting);
+            }
+            return notificationSettingConverter.toDto(setting);
+        } catch (CustomException ce) {
+            throw ce;
         } catch (Exception e) {
             throw new CustomException(ErrorCode.NOTIFICATION_SETTING_UPDATE_FAILED);
         }

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
@@ -2,6 +2,7 @@ package store.lastdance.service.notification;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.lastdance.converter.notification.NotificationSettingConverter;
@@ -79,13 +80,9 @@ public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Se
     @Override
     public void createDefaultSetting(UUID userId) {
         try {
-            NotificationSetting existing = settingRepository.findByUserId(userId).orElse(null);
-            if (existing != null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_ALREADY_EXISTS);
-
-            NotificationSetting defaultSetting = notificationSettingConverter.toEntity(userId);
-            
-            settingRepository.save(defaultSetting);
-
+            settingRepository.save(notificationSettingConverter.toEntity(userId));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_ALREADY_EXISTS);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.NOTIFICATION_SETTING_CREATE_FAILED);
         }

--- a/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
+++ b/src/main/java/store/lastdance/service/notification/NotificationSettingV2ServiceImpl.java
@@ -1,0 +1,95 @@
+package store.lastdance.service.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import store.lastdance.domain.notification.NotificationSetting;
+import store.lastdance.dto.notification.NotificationSettingRequestDTO;
+import store.lastdance.dto.notification.NotificationSettingResponseDTO;
+import store.lastdance.exception.CustomException;
+import store.lastdance.exception.ErrorCode;
+import store.lastdance.repository.notification.NotificationSettingRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationSettingV2ServiceImpl implements NotificationSettingV2Service {
+
+    private final NotificationSettingRepository settingRepository;
+
+    @Override
+    public NotificationSettingResponseDTO getUserSetting(UUID userId) {
+        NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
+        if (setting == null) {
+            createDefaultSetting(userId);
+            return NotificationSettingResponseDTO.builder()
+                    .settingId(null)
+                    .userId(userId)
+                    .emailEnabled(false)
+                    .scheduleReminder(false)
+                    .paymentReminder(false)
+                    .checklistReminder(false)
+                    .sseEnabled(false)
+                    .createdAt(null)
+                    .build();
+        }
+
+        return NotificationSettingResponseDTO.builder()
+                .settingId(setting.getSettingId())
+                .userId(setting.getUserId())
+                .emailEnabled(setting.getEmailEnabled() != null ? setting.getEmailEnabled() : true)
+                .scheduleReminder(setting.getScheduleReminder() != null ? setting.getScheduleReminder() : true)
+                .paymentReminder(setting.getPaymentReminder() != null ? setting.getPaymentReminder() : true)
+                .checklistReminder(setting.getChecklistReminder() != null ? setting.getChecklistReminder() : true)
+                .sseEnabled(setting.getSseEnabled() != null ? setting.getSseEnabled() : true)
+                .createdAt(setting.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    public void updateSetting(UUID userId, NotificationSettingRequestDTO request) {
+        NotificationSetting setting = settingRepository.findByUserId(userId).orElse(null);
+
+        if (setting == null) {
+            setting = NotificationSetting.builder()
+                    .userId(userId)
+                    .build();
+        }
+
+        if (request.getEmailEnabled() != null) {
+            setting.updateEmailEnabled(request.getEmailEnabled());
+        }
+        if (request.getScheduleReminder() != null) {
+            setting.updateScheduleReminder(request.getScheduleReminder());
+        }
+        if (request.getPaymentReminder() != null) {
+            setting.updatePaymentReminder(request.getPaymentReminder());
+        }
+        if (request.getChecklistReminder() != null) {
+            setting.updateChecklistReminder(request.getChecklistReminder());
+        }
+        if (request.getSseEnabled() != null) {
+            setting.updateSSEEnabled(request.getSseEnabled());
+        }
+        settingRepository.save(setting);
+    }
+
+    @Override
+    public void createDefaultSetting(UUID userId) {
+        try {
+            NotificationSetting existing = settingRepository.findByUserId(userId).orElse(null);
+            if (existing != null) throw new CustomException(ErrorCode.NOTIFICATION_SETTING_ALREADY_EXISTS);
+
+            NotificationSetting defaultSetting = NotificationSetting.builder()
+                    .userId(userId)
+                    .build();
+            
+            settingRepository.save(defaultSetting);
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.NOTIFICATION_SETTING_CREATE_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- [x] 브랜치명 : refactor/v2-도메인명-세부내용
- [x] 컨트롤러 v1: 기존 클래스 유지, v2: XxxV2Controller.java
- [x] 서비스 v1: 기존 클래스 유지, v2: XxxV2Service.java
- [x] NotificationSettingConverter.java 생성 (엔티티 <-> DTO 변환)
- [x] 기존 서비스에서 DTO 변환 코드 제거

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #237 와 연결됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 내 알림 설정 조회(GET) 및 수정(PATCH) API(/api/v2/notification-settings/me) 추가.
  * 이메일, 일정/결제/체크리스트 리마인더 및 SSE 토글을 개별 관리 가능.
  * 사용자가 없을 경우 기본 알림 설정을 자동 생성.

* **Bug Fixes**
  * 알림 관련 기본값을 모두 OFF로 변경해 불필요한 알림 발송 방지 및 응답 일관성 개선.
  * 조회/생성/수정 실패에 대한 명확한 오류 코드 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->