### PR TITLE
fix: 가계부 조회 오류 및 분석 이력 조회 오류 수정

### DIFF
--- a/src/main/java/store/lastdance/domain/analysis/ExpenseAnalysisHistory.java
+++ b/src/main/java/store/lastdance/domain/analysis/ExpenseAnalysisHistory.java
@@ -1,7 +1,6 @@
 package store.lastdance.domain.analysis;
 
 import jakarta.persistence.*;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,9 +24,6 @@ public class ExpenseAnalysisHistory extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Version
-    private Long version;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/store/lastdance/repository/expense/ExpenseRepositoryImpl.java
+++ b/src/main/java/store/lastdance/repository/expense/ExpenseRepositoryImpl.java
@@ -59,7 +59,7 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findPersonalExpensesForCombined(User user, LocalDate startDate, LocalDate endDate, ExpenseCategory category, String search, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var personalQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.user.eq(user),
@@ -68,10 +68,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                         categoryEq(category),
                         searchContains(search)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            personalQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = personalQuery.fetch();
         Long total = queryFactory
                 .select(expense.count())
                 .from(expense)
@@ -252,7 +253,7 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findShareExpensesForCombined(User user, LocalDate startDate, LocalDate endDate, ExpenseCategory category, String search, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var shareQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.user.eq(user),
@@ -261,10 +262,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                         categoryEq(category),
                         searchContains(search)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            shareQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = shareQuery.fetch();
 
         Long total = queryFactory
                 .select(expense.count())

--- a/src/main/java/store/lastdance/repository/expense/ExpenseRepositoryImpl.java
+++ b/src/main/java/store/lastdance/repository/expense/ExpenseRepositoryImpl.java
@@ -119,17 +119,18 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findGroupExpensesByMonthWithPaging(Group group, LocalDate startDate, LocalDate endDate, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var groupMonthQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.group.eq(group),
                         expense.expenseType.eq(ExpenseType.GROUP),
                         expense.expenseDate.between(startDate, endDate)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            groupMonthQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = groupMonthQuery.fetch();
 
         Long total = queryFactory
                 .select(expense.count())
@@ -219,7 +220,7 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findShareExpensesByGroupAndMonthWithPagingFiltered(User user, Group group, LocalDate startDate, LocalDate endDate, ExpenseCategory category, String search, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var shareGroupQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.user.eq(user),
@@ -229,10 +230,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                         categoryEq(category),
                         searchContains(search)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            shareGroupQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = shareGroupQuery.fetch();
 
         Long total = queryFactory
                 .select(expense.count())
@@ -382,7 +384,7 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findGroupExpensesBySearchAndMonthWithPaging(Group group, String search, LocalDate startDate, LocalDate endDate, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var groupSearchQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.group.eq(group),
@@ -390,10 +392,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                         expense.expenseDate.between(startDate, endDate),
                         searchContains(search)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            groupSearchQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = groupSearchQuery.fetch();
 
         Long total = queryFactory
                 .select(expense.count())
@@ -412,7 +415,7 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
 
     @Override
     public Page<Expense> findGroupExpensesByCategoryAndMonthWithPaging(Group group, ExpenseCategory category, LocalDate startDate, LocalDate endDate, Pageable pageable) {
-        List<Expense> content = queryFactory
+        var groupCategoryQuery = queryFactory
                 .selectFrom(expense)
                 .where(
                         expense.group.eq(group),
@@ -420,10 +423,11 @@ public class ExpenseRepositoryImpl implements ExpenseRepositoryCustom {
                         expense.expenseDate.between(startDate, endDate),
                         categoryEq(category)
                 )
-                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .orderBy(expense.expenseDate.desc(), expense.createdAt.desc());
+        if (pageable.isPaged()) {
+            groupCategoryQuery.offset(pageable.getOffset()).limit(pageable.getPageSize());
+        }
+        List<Expense> content = groupCategoryQuery.fetch();
 
         Long total = queryFactory
                 .select(expense.count())


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세
 - fix: Pageable.unpaged() 전달 시 QueryDSL offset/limit 호출로 인한 UnsupportedOperationException 수정 (ExpenseRepositoryImpl 전체 메서드)
  - fix: ExpenseAnalysisHistory 엔티티의 불필요한 @Version 필드 제거 (DB 컬럼 미존재로 인한 쿼리 오류)
  
## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| (캡처) | (캡처) |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인

## 📝 참고 사항
  - `/api/v1/expenses/personal/combined` 등 500 오류 해결                                 
  - `/api/v1/expenses/analyze/history` 500 오류 해결
